### PR TITLE
Fix getset behavior

### DIFF
--- a/lib/fakeredis/strings.rb
+++ b/lib/fakeredis/strings.rb
@@ -34,7 +34,6 @@ module FakeRedis
       end
 
       def getset(key, value)
-        return unless @data[key]
         old_value = @data[key]
         @data[key] = value
         return old_value

--- a/spec/strings_spec.rb
+++ b/spec/strings_spec.rb
@@ -56,8 +56,13 @@ module FakeRedis
       @client.getset("key1", "value2").should == "value1"
       @client.get("key1").should == "value2"
     end
+    
+    it "should return nil for #getset if the key does not exist when setting" do
+      @client.getset("key1", "value1").should == nil
+      @client.get("key1").should == "value1"
+    end
 
-      it "should increment the integer value of a key by one" do
+    it "should increment the integer value of a key by one" do
       @client.set("counter", "1")
       @client.incr("counter")
 


### PR DESCRIPTION
Fix behavior of getset which should return nil and set the key and value even if the key does not exist.

It seems as if reading the documentation for this command, http://redis.io/commands/getset, that the key and value should be set even if the key does not exist. 

You can test this behavior is as expected on the command page as well by using the following:

redis> GETSET somekey "value1"
(nil)
redis> GET somekey
"value1"
redis>  
