### PR TITLE
Fix the return values for sadd, srem, smove, persist, hset, and hsetnx

### DIFF
--- a/spec/hashes_spec.rb
+++ b/spec/hashes_spec.rb
@@ -77,15 +77,16 @@ module FakeRedis
     end
 
     it "should set the string value of a hash field" do
-      @client.hset("key1", "k1", "val1")
+      @client.hset("key1", "k1", "val1").should == true
+      @client.hset("key1", "k1", "val1").should == false
 
       @client.hget("key1", "k1").should == "val1"
     end
 
     it "should set the value of a hash field, only if the field does not exist" do
       @client.hset("key1", "k1", "val1")
-      @client.hsetnx("key1", "k1", "value")
-      @client.hsetnx("key1", "k2", "val2")
+      @client.hsetnx("key1", "k1", "value").should == false
+      @client.hsetnx("key1", "k2", "val2").should == true
 
       @client.hget("key1", "k1").should == "val1"
       @client.hget("key1", "k2").should == "val2"

--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -94,7 +94,9 @@ puts "checking existence"
 
     it "should remove the expiration from a key" do
       @client.set("key1", "1")
-      @client.persist("key1")
+      @client.expireat("key1", Time.now.to_i)
+      @client.persist("key1").should == true
+      @client.persist("key1").should == false
 
       @client.ttl("key1").should == -1
     end

--- a/spec/sets_spec.rb
+++ b/spec/sets_spec.rb
@@ -7,7 +7,8 @@ module FakeRedis
     end
 
     it "should add a member to a set" do
-      @client.sadd("key", "value")
+      @client.sadd("key", "value").should == true
+      @client.sadd("key", "value").should == false
 
       @client.smembers("key").should == ["value"]
     end
@@ -93,7 +94,8 @@ module FakeRedis
       @client.sadd("key1", "a")
       @client.sadd("key1", "b")
       @client.sadd("key2", "c")
-      @client.smove("key1", "key2", "a")
+      @client.smove("key1", "key2", "a").should == true
+      @client.smove("key1", "key2", "a").should == false
 
       @client.smembers("key1").should == ["b"]
       @client.smembers("key2").should =~ ["c", "a"]
@@ -118,7 +120,8 @@ module FakeRedis
     it "should remove a member from a set" do
       @client.sadd("key1", "a")
       @client.sadd("key1", "b")
-      @client.srem("key1", "a")
+      @client.srem("key1", "a").should == true
+      @client.srem("key1", "a").should == false
 
       @client.smembers("key1").should == ["b"]
     end


### PR DESCRIPTION
This change fixes the return values for sadd, srem, smove, persist, hset, and hsetnx so that redis-rb properly returns true / false for those calls.
