### PR TITLE
Fix missing typecast in setex

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -610,7 +610,7 @@ class Redis
       end
 
       def setex(key, seconds, value)
-        @data[key] = value
+        @data[key] = value.to_s
         expire(key, seconds)
       end
 

--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -138,5 +138,13 @@ module FakeRedis
       @client.type("key1").should == "string"
       @client.type("key0").should == "none"
     end
+
+    it "should convert the value into a string before storing" do
+      @client.set("key1", 1)
+      @client.get("key1").should == "1"
+
+      @client.setex("key2", 30, 1)
+      @client.get("key2").should == "1"
+    end
   end
 end


### PR DESCRIPTION
fakeredis has the following incorrect behavior

```
client.setex("key2", 30, 1)
client.get("key2")    #=> 1
```

The result should be a string, "1".
