### PR TITLE
HMSet should reject more things

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -526,7 +526,7 @@ class Redis
       end
 
       def hmset(key, *fields)
-        raise ArgumentError, "wrong number of arguments for 'hmset' command" if fields.empty?
+        raise ArgumentError, "wrong number of arguments for 'hmset' command" if fields.empty? || fields.size.odd?
         data_type_check(key, Hash)
         @data[key] ||= {}
         fields.each_slice(2) do |field|

--- a/spec/hashes_spec.rb
+++ b/spec/hashes_spec.rb
@@ -99,6 +99,12 @@ module FakeRedis
       @client.exists("key").should be_false
     end
 
+    it 'rejects an insert with a key but no value' do
+      lambda { @client.hmset("key", 'foo') }.should raise_error(ArgumentError)
+      lambda { @client.hmset("key", 'foo', 3, 'bar') }.should raise_error(ArgumentError)
+      @client.exists("key").should be_false
+    end
+
     it "should set multiple hash fields to multiple values" do
       @client.hmset("key", "k1", "value1", "k2", "value2")
 


### PR DESCRIPTION
Redis throws an error when you try and do an hmset with a key but no value. This commit makes fakeredis mirror that.
