### PR TITLE
Substr and proper args for mget

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -181,6 +181,7 @@ class Redis
       end
 
       def mget(*keys)
+        raise ArgumentError, "wrong number of arguments for 'mget' command" if keys.empty?
         @data.values_at(*keys)
       end
 

--- a/spec/strings_spec.rb
+++ b/spec/strings_spec.rb
@@ -99,6 +99,12 @@ module FakeRedis
       @client.mget("key1", "key2", "key3").should == ["value1", "value2", "value3"]
     end
 
+    it 'raises an argument error when not passed any fields' do
+      @client.set("key3", "value3")
+
+      lambda { @client.mget }.should raise_error(ArgumentError)
+    end
+
     it "should set multiple keys to multiple values" do
       @client.mset(:key1, "value1", :key2, "value2")
 


### PR DESCRIPTION
This implements substr (really just an alias to getrange) and makes mget blow up when you call it without args.
