### PR TITLE
Sorted set fixes

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -690,12 +690,22 @@ class Redis
         "OK"
       end
 
-      def zadd(key, score, value)
+      def zadd(key, *args)
         data_type_check(key, ZSet)
         @data[key] ||= ZSet.new
-        exists = @data[key].key?(value.to_s)
-        @data[key][value.to_s] = score
-        !exists
+
+        if args.size == 1 && args[0].is_a?(Array)
+          exists = args.map(&:last).map { |el| @data[key].key?(el.to_s) }.count(true)
+          args.each { |score, value| @data[key][value.to_s] = score }
+        elsif args.size == 2
+          score, value = args
+          exists = !@data[key].key?(value.to_s)
+          @data[key][value.to_s] = score
+        else
+          raise ArgumentError, "wrong number of arguments for 'zadd' command" if keys.empty?
+        end
+
+        exists
       end
 
       def zrem(key, value)

--- a/spec/sorted_sets_spec.rb
+++ b/spec/sorted_sets_spec.rb
@@ -14,6 +14,10 @@ module FakeRedis
       @client.zscore("key", "val").should == 2.0
     end
 
+    it 'adds multiple things to a set' do
+      @client.zadd("key", [[1, "val"], [2, 'val2']]).should == 1
+    end
+
     it "should allow floats as scores when adding or updating" do
       @client.zadd("key", 4.321, "val").should be(true)
       @client.zscore("key", "val").should == 4.321


### PR DESCRIPTION
Updating some of the sorted set methods to match how they work in redis / redis-rb.

@guilleiguaran Can you pull this into the 3.2 version of the gem? We haven't been able to upgrade to redis-rb 3.0 and are still on 3.2 because of it.
