### PR TITLE
Fixing bug in zremrangebyrank

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -863,6 +863,7 @@ class Redis
 
       def zremrangebyrank(key, start, stop)
         sorted_elements = @data[key].sort { |(v_a, r_a), (v_b, r_b)| r_a <=> r_b }
+        start = sorted_elements.length if start > sorted_elements.length
         elements_to_delete = sorted_elements[start..stop]
         elements_to_delete.each { |elem, rank| @data[key].delete(elem) }
         elements_to_delete.size

--- a/spec/sorted_sets_spec.rb
+++ b/spec/sorted_sets_spec.rb
@@ -203,6 +203,15 @@ module FakeRedis
         @client.zremrangebyrank("key", 0, 1).should == 2
         @client.zcard('key').should == 1
       end
+
+      it 'handles out of range requests' do
+        @client.zadd("key", 1, "one")
+        @client.zadd("key", 2, "two")
+        @client.zadd("key", 3, "three")
+
+        @client.zremrangebyrank("key", 25, -1).should == 0
+        @client.zcard('key').should == 3
+      end
     end
 
     #it "should remove all members in a sorted set within the given indexes"


### PR DESCRIPTION
Implementing a ring buffer often does a "trim" of the set, regardless of its size
