### PR TITLE
Correctly support variadic lpush/rpush commands

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -311,7 +311,9 @@ class Redis
       def rpush(key, value)
         data_type_check(key, Array)
         @data[key] ||= []
-        @data[key].push(value)
+        [value].flatten.each do |val|
+          @data[key].push(val.to_s)
+        end
         @data[key].size
       end
 
@@ -324,7 +326,9 @@ class Redis
       def lpush(key, value)
         data_type_check(key, Array)
         @data[key] ||= []
-        @data[key].unshift(value)
+        [value].flatten.each do |val|
+          @data[key].unshift(val.to_s)
+        end
         @data[key].size
       end
 

--- a/spec/lists_spec.rb
+++ b/spec/lists_spec.rb
@@ -22,6 +22,16 @@ module FakeRedis
 
       @client.lrange("key1", 0, -1).should == ["v1", "v2", "v3"]
     end
+    
+    it 'should allow multiple values to be added to a list in a single rpush' do
+      @client.rpush('key1', [1, 2, 3])
+      @client.lrange('key1', 0, -1).should == ['1', '2', '3']
+    end
+    
+    it 'should allow multiple values to be added to a list in a single lpush' do
+      @client.lpush('key1', [1, 2, 3])
+      @client.lrange('key1', 0, -1).should == ['3', '2', '1']
+    end
 
     it "should error if an invalid where argument is given" do
       @client.rpush("key1", "v1")


### PR DESCRIPTION
Prior to this commit, passing an array as the second argument to lpush/rpush would result in the array stored in a single value - ex: `rpush('key', ['a', b', 'c'])` would result in `[['a', 'b', 'c']]`. Added simple support to both commands to mirror the behavior of the 3.0 redis-rb client - the same command resulting in `['a', 'b', 'c']`. Added test coverage to document this behavior.
