### PR TITLE
`get` needs to be type checked as well

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -164,6 +164,7 @@ class Redis
       def bgreriteaof ; end
 
       def get(key)
+        data_type_check(key, String)
         @data[key]
       end
 
@@ -893,7 +894,8 @@ class Redis
 
         def data_type_check(key, klass)
           if @data[key] && !@data[key].is_a?(klass)
-            fail "Operation against a key holding the wrong kind of value: Expected #{klass} at #{key}."
+            warn "Operation against a key holding the wrong kind of value: Expected #{klass} at #{key}."
+            raise Redis::CommandError.new("ERR Operation against a key holding the wrong kind of value")
           end
         end
 

--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -160,5 +160,13 @@ module FakeRedis
       @client.setex("key2", 30, 1)
       @client.get("key2").should == "1"
     end
+
+    it "should only operate against keys containing string values" do
+      @client.sadd("key1", "one")
+      lambda { @client.get("key1") }.should raise_error(Redis::CommandError, "ERR Operation against a key holding the wrong kind of value")
+
+      @client.hset("key2", "one", "two")
+      lambda { @client.get("key2") }.should raise_error(Redis::CommandError, "ERR Operation against a key holding the wrong kind of value")
+    end
   end
 end


### PR DESCRIPTION
Patch to check data type in `get` accessing keys - it should raise an error if you call get on a key containing a set for instance. Previous behaviour was to return the ruby `Set` instance.

Also raises a `Redis::CommandError` for wrong key value types, to match the redis-rb gem's behaviour.
