### PR TITLE
Type check & delegate to #set from #getset

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -180,9 +180,10 @@ class Redis
       alias :substr :getrange
 
       def getset(key, value)
-        old_value = @data[key]
-        @data[key] = value
-        return old_value
+        data_type_check(key, String)
+        @data[key].tap do
+          set(key, value)
+        end
       end
 
       def mget(*keys)

--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -159,14 +159,19 @@ module FakeRedis
 
       @client.setex("key2", 30, 1)
       @client.get("key2").should == "1"
+
+      @client.getset("key3", 1)
+      @client.get("key3").should == "1"
     end
 
     it "should only operate against keys containing string values" do
       @client.sadd("key1", "one")
       lambda { @client.get("key1") }.should raise_error(Redis::CommandError, "ERR Operation against a key holding the wrong kind of value")
+      lambda { @client.getset("key1", 1) }.should raise_error(Redis::CommandError, "ERR Operation against a key holding the wrong kind of value")
 
       @client.hset("key2", "one", "two")
       lambda { @client.get("key2") }.should raise_error(Redis::CommandError, "ERR Operation against a key holding the wrong kind of value")
+      lambda { @client.getset("key2", 1) }.should raise_error(Redis::CommandError, "ERR Operation against a key holding the wrong kind of value")
     end
   end
 end


### PR DESCRIPTION
`getset` only operates against string values, so the key needs to be checked to hold a string. And it should also convert the value set to a string, so it just delegates to `set` in the implementation for that now.
