### PR TITLE
Support passing an Array of pairs to HMSET.

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -550,16 +550,20 @@ class Redis
           raise Redis::CommandError, "ERR wrong number of arguments for HMSET"
         end
 
-        is_array_of_pairs = fields.all?{|field| field.instance_of?(Array) and field.length == 2}
+        is_list_of_arrays = fields.all?{|field| field.instance_of?(Array)}
 
-        if fields.size.odd? and !is_array_of_pairs
+        if fields.size.odd? and !is_list_of_arrays
+          raise Redis::CommandError, "ERR wrong number of arguments for HMSET"
+        end
+
+        if is_list_of_arrays and !fields.all?{|field| field.length == 2}
           raise Redis::CommandError, "ERR wrong number of arguments for HMSET"
         end
 
         data_type_check(key, Hash)
         data[key] ||= {}
 
-        if (is_array_of_pairs)
+        if (is_list_of_arrays)
           fields.each do |pair|
             data[key][pair[0].to_s] = pair[1].to_s
           end

--- a/spec/hashes_spec.rb
+++ b/spec/hashes_spec.rb
@@ -160,5 +160,9 @@ module FakeRedis
       @client.hget("key1", :k3).should be == "val3"
     end
 
+    it "should reject a list of arrays that contain an invalid number of arguments" do
+      expect { @client.hmset("key1", [:k1, "val1"], [:k2, "val2", "bogus val"]) }.to raise_error(Redis::CommandError, "ERR wrong number of arguments for HMSET")
+    end
+
   end
 end


### PR DESCRIPTION
invoking hmset("key", [:k1, "val1"], [:k2, "val2]) is supported in redis-rb, so i've implemented it here.
