### PR TITLE
Support for ltrim with negative start (max set size)

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -266,7 +266,18 @@ class Redis
       def ltrim(key, start, stop)
         data_type_check(key, Array)
         return unless data[key]
-        data[key] = data[key][start..stop]
+
+        if start < 0 && data[key].count < start.abs
+          # Example: we have a list of 3 elements and
+          # we give it a ltrim list, -5, -1. This means
+          # it should trim to a max of 5. Since 3 < 5
+          # we should not touch the list. This is consistent
+          # with behavior of real Redis's ltrim with a negative
+          # start argument.
+          data[key]
+        else
+          data[key] = data[key][start..stop]
+        end
       end
 
       def lindex(key, index)

--- a/spec/lists_spec.rb
+++ b/spec/lists_spec.rb
@@ -123,6 +123,39 @@ module FakeRedis
       @client.lrange("key1", 0, -1).should be == ["two", "three"]
     end
 
+
+    context "when the list is smaller than the requested trim" do
+      before { @client.rpush("listOfOne", "one") }
+
+      context "trimming with a negative start (specifying a max)" do
+        before { @client.ltrim("listOfOne", -5, -1) }
+
+        it "returns the unmodified list" do
+          @client.lrange("listOfOne", 0, -1).should be == ["one"]
+        end
+      end
+    end
+
+    context "when the list is larger than the requested trim" do
+      before do
+        @client.rpush("maxTest", "one")
+        @client.rpush("maxTest", "two")
+        @client.rpush("maxTest", "three")
+        @client.rpush("maxTest", "four")
+        @client.rpush("maxTest", "five")
+        @client.rpush("maxTest", "six")
+      end
+
+      context "trimming with a negative start (specifying a max)" do
+        before { @client.ltrim("maxTest", -5, -1) }
+
+        it "should trim a list to the specified maximum size" do
+          @client.lrange("maxTest", 0, -1).should be == ["two","three", "four", "five", "six"]
+        end
+      end
+    end
+
+
     it "should remove and return the last element in a list" do
       @client.rpush("key1", "one")
       @client.rpush("key1", "two")


### PR DESCRIPTION
Adds support for ltrim with negative offset to behave correctly. This is used for example by redis-objects in their List maxlength implementation.

Redis's correct behavior using ltrim with negative offset is like this:

```
redis.rpush "mylist", "firstitem"
redis.lrange "mylist", 0, -1 == ["firstitem"] # returns the first item
redis.ltrim "mylist", -5, -1 # this truncates the list to a max of 5 items from the right side
redis.lrange "mylist", 0, -1 == ["firstitem"] # nothing should happen to the list
```

The pull request includes specs that demonstrate the correct behavior both for lists smaller than the negative start, and larger. If the list is larger, fakeredis correctly trims it. However if the list is smaller, fakeredis incorrectly returns zero items instead of returning the smaller list.
