### PR TITLE
Updating 'redis_version' returned by info to match latest versions of Redis

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -131,7 +131,7 @@ class Redis
 
       def info
         {
-          "redis_version" => "0.07",
+          "redis_version" => "2.6.16",
           "connected_clients" => "1",
           "connected_slaves" => "0",
           "used_memory" => "3187",


### PR DESCRIPTION
In order to avoid errors when using **fakeredis** with other gems like [Redistat](https://github.com/jimeh/redistat) which throws an error because the version of the _fake_ redis is too old.
