### PR TITLE
Subtracting from a nonexistent set

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -462,7 +462,7 @@ class Redis
       def sdiff(key1, *keys)
         [key1, *keys].each { |k| data_type_check(k, ::Set) }
         keys = keys.map { |k| data[k] || ::Set.new }
-        keys.inject(data[key1]) do |memo, set|
+        keys.inject(data[key1] || Set.new) do |memo, set|
           memo - set
         end.to_a
       end

--- a/spec/sets_spec.rb
+++ b/spec/sets_spec.rb
@@ -46,6 +46,13 @@ module FakeRedis
       @client.sdiff("key1", "key2", "key3").should =~ ["b", "d"]
     end
 
+    it "should subtract from a nonexistent set" do
+      @client.sadd("key2", "a")
+      @client.sadd("key2", "b")
+
+      @client.sdiff("key1", "key2").should == []
+    end
+
     it "should subtract multiple sets and store the resulting set in a key" do
       @client.sadd("key1", "a")
       @client.sadd("key1", "b")


### PR DESCRIPTION
Given an empty Redis database, the following works but fails with a `NoMethodError` with fakeredis:

``` ruby
r = Redis.new
r.sadd("demo", "a")
r.sadd("demo", "b")
r.sdiff("nonexistent-key", "demo")
=> []
```

The exception raised by fakeredis:

``` ruby
NoMethodError:
       undefined method `-' for nil:NilClass
```

The pull request fixes the problem so that it behaves the same as Redis. Thanks for merging/fixing it.
