### PR TITLE
Updated the set method to allow options as per redis-rb 3.0.6. 

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -646,8 +646,23 @@ class Redis
         set(key, value)
       end
 
-      def set(key, value)
+      def set(key, value, *array_options)
+        option_nx = array_options.delete("NX")
+        option_xx = array_options.delete("XX")
+
+        return false if option_nx && option_xx
+
+        return false if option_nx && exists(key)
+        return false if option_xx && !exists(key)
+
         data[key] = value.to_s
+
+        options = Hash[array_options.each_slice(2).to_a]
+        ttl_in_seconds = options["EX"] if options["EX"]
+        ttl_in_seconds = options["PX"] / 1000.0 if options["PX"]
+
+        expire(key, ttl_in_seconds) if ttl_in_seconds
+
         "OK"
       end
 

--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -265,5 +265,61 @@ module FakeRedis
       @client.select(0)
       @client.get("key1").should be == "1"
     end
+
+    context "with extended options" do
+      it "uses ex option to set the expire time, in seconds" do
+        now = Time.now
+        Time.stub({ :now => now })
+        ttl = 7
+
+        @client.set("key1", "1", { :ex => ttl }).should == "OK"
+        @client.client.connection.find_database.expires["key1"].should == now + ttl
+      end
+
+      it "uses px option to set the expire time, in miliseconds" do
+        now = Time.now
+        Time.stub({ :now => now })
+        ttl = 7000
+
+        @client.set("key1", "1", { :px => ttl }).should == "OK"
+        @client.client.connection.find_database.expires["key1"].should == now + (ttl / 1000)
+      end
+
+      # Note that the redis-rb implementation will always give PX last.
+      # Redis seems to process each expiration option and the last one wins.
+      it "prefers the finer-grained PX expiration option over EX" do
+        now = Time.now
+        Time.stub({ :now => now })
+        ttl_px = 5555
+        ttl_ex = 10
+
+        @client.set("key1", "1", { :px => ttl_px, :ex => ttl_ex })
+        @client.client.connection.find_database.expires["key1"].should == now + (ttl_px / 1000.0)
+
+        @client.set("key1", "1", { :ex => ttl_ex, :px => ttl_px })
+        @client.client.connection.find_database.expires["key1"].should == now + (ttl_px / 1000.0)
+      end
+
+      it "uses nx option to only set the key if it does not already exist" do
+        @client.set("key1", "1", { :nx => true }).should == true
+        @client.set("key1", "2", { :nx => true }).should == false
+
+        @client.get("key1").should == "1"
+      end
+
+      it "uses xx option to only set the key if it already exists" do
+        @client.set("key2", "1", { :xx => true }).should == false
+        @client.set("key2", "2")
+        @client.set("key2", "1", { :xx => true }).should == true
+
+        @client.get("key2").should == "1"
+      end
+
+      it "does not set the key if both xx and nx option are specified" do
+        @client.set("key2", "1", { :nx => true, :xx => true }).should == false
+        @client.get("key2").should be_nil
+      end
+    end
   end
 end
+


### PR DESCRIPTION
pair: @ebenoist

This should resolve issue #79

We left the method a little fat, as we weren't sure what kind of method abstraction you prefer in the code base.

Let us know if you have any questions.

Cheers,
Dave & Erik
