### PR TITLE
Fix type method for sorted sets

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -713,6 +713,7 @@ class Redis
         case data[key]
           when nil then "none"
           when String then "string"
+          when ZSet then "zset"
           when Hash then "hash"
           when Array then "list"
           when ::Set then "set"

--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -150,10 +150,28 @@ module FakeRedis
     end
 
     it "should determine the type stored at key" do
-      @client.set("key1", "1")
-
-      @client.type("key1").should be == "string"
+      # Non-existing key
       @client.type("key0").should be == "none"
+
+      # String
+      @client.set("key1", "1")
+      @client.type("key1").should be == "string"
+
+      # List
+      @client.lpush("key2", "1")
+      @client.type("key2").should be == "list"
+
+      # Set
+      @client.sadd("key3", "1")
+      @client.type("key3").should be == "set"
+
+      # Sorted Set
+      @client.zadd("key4", 1.0, "1")
+      @client.type("key4").should be == "zset"
+
+      # Hash
+      @client.hset("key5", "a", "1")
+      @client.type("key5").should be == "hash"
     end
 
     it "should convert the value into a string before storing" do


### PR DESCRIPTION
The `type` method returned "hash" for sorted sets, should be "zset", see http://redis.io/commands/type
