### PR TITLE
Temporary fix for rb 1.8.7 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+before_install:
+  - gem update bundler
+  - bundle --version
+  - gem update --system 2.1.11
+  - gem --version
+
 rvm:
   - 1.8.7
   - 1.9.2


### PR DESCRIPTION
Ruby 1.8.7 is broken otherwise, but doing this fixes it. No harm in running it for other rubies either.

See https://github.com/bundler/bundler/issues/2784 and https://github.com/travis-ci/travis-ci/issues/1793 for more context on the bug.

We should revert this once Travis has fixed it and rolled the fix out.
