### PR TITLE
Adds robustness to the zremrangebyrank method

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -911,6 +911,17 @@ class Redis
         range.size
       end
 
+      def zremrangebyrank(key, start, stop)
+        data_type_check(key, ZSet)
+        return 0 unless data[key]
+
+        sorted_elements = data[key].sort_by { |k, v| v }
+        start = sorted_elements.length if start > sorted_elements.length
+        elements_to_delete = sorted_elements[start..stop]
+        elements_to_delete.each { |elem, rank| data[key].delete(elem) }
+        elements_to_delete.size
+      end
+
       def zinterstore(out, *args)
         data_type_check(out, ZSet)
         args_handler = SortedSetArgumentHandler.new(args)
@@ -923,14 +934,6 @@ class Redis
         args_handler = SortedSetArgumentHandler.new(args)
         data[out] = SortedSetUnionStore.new(args_handler, data).call
         data[out].size
-      end
-
-      def zremrangebyrank(key, start, stop)
-        sorted_elements = data[key].sort_by { |k, v| v }
-        start = sorted_elements.length if start > sorted_elements.length
-        elements_to_delete = sorted_elements[start..stop]
-        elements_to_delete.each { |elem, rank| data[key].delete(elem) }
-        elements_to_delete.size
       end
 
       private

--- a/spec/sorted_sets_spec.rb
+++ b/spec/sorted_sets_spec.rb
@@ -333,6 +333,10 @@ module FakeRedis
         @client.zremrangebyrank("key", 25, -1).should be == 0
         @client.zcard('key').should be == 3
       end
+
+      it "should return 0 if the key didn't exist" do
+        @client.zremrangebyrank("key", 0, 1).should be == 0
+      end
     end
 
     describe "#zunionstore" do


### PR DESCRIPTION
I'm running into an error when removing the last item of a set, and then trying to trim a set down to a specific cap.  With Redis, I don't need to check the length of a set before calling `zremrangebyrank` so I don't want to put that check in my production code.  The set is missing because it gets removed by `remove_key_for_empty_collection`.

Here is the pseudocode for repro.  This block will apply a diff update to an existing list, but fails in FakeRedis if the last item gets removed:

``` ruby
    if items_to_remove.any?
      list.redis.zrem list.key, items_to_remove.map { |i| list.to_redis(i) }
    end

    if items_to_add.any?
      list.merge items_to_add
    end

    # prune the list to fit within the cap
    list.remrangebyrank(0, -1 - Settings.buffer_size)
```

This pull request adds the same validation all the other methods use (see `zrevrangebyscore`), and also moves the method above next to its cousin `zremrangebyscore` rather than being next to the disssimilar `zinterstore` and `zunionstore`
