### PR TITLE
allow srandmembers to take an optional parameter for the number of elements

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -478,8 +478,10 @@ class Redis
         return [] unless data[key]
         if number.nil?
           data[key].to_a[rand(data[key].size)]
-        else
+        elsif number >= 0
           data[key].to_a.sample(number)
+        else
+          (1..-number).flat_map { data[key].to_a.sample(1) }
         end
       end
 

--- a/spec/sets_spec.rb
+++ b/spec/sets_spec.rb
@@ -223,6 +223,27 @@ module FakeRedis
         end
       end
 
+      context 'when called with an optional parameter of -100' do
+        it 'is an array of 100 random elements from the set, some of which are repeated' do
+          random_elements = @client.srandmember("key1", -100)
+
+          random_elements.count.should == 100
+          random_elements.uniq.count.should <= 3
+          random_elements.all? do |element|
+            ['a', 'b', 'c'].include?(element).should be_true
+          end
+        end        
+      end
+
+      context 'when called with an optional parameter of 100' do
+        it 'is an array of all of the elements from the set, none of which are repeated' do
+          random_elements = @client.srandmember("key1", 100)
+
+          random_elements.count.should == 3
+          random_elements.uniq.count.should == 3
+          random_elements.should =~ ['a', 'b', 'c']
+        end
+      end
     end
 
     context 'with an empty set' do


### PR DESCRIPTION
Redis supports an optional parameter for srandmember. This adds some of that behavior. 

Documentation for SRANDMEMBER: http://redis.io/commands/srandmember
"Starting from Redis version 2.6, when called with the additional count argument, return an array of count distinct elements if count is positive."
