### PR TITLE
Support the SCAN command

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -755,6 +755,39 @@ class Redis
         "OK"
       end
 
+      def scan(start_cursor, *args)
+        match = "*"
+        count = 10
+
+        if args.size.odd?
+          raise_argument_error('scan')
+        end
+
+        if idx = args.index("MATCH")
+          match = args[idx + 1]
+        end
+
+        if idx = args.index("COUNT")
+          count = args[idx + 1]
+        end
+
+        start_cursor = start_cursor.to_i
+        data_type_check(start_cursor, Fixnum)
+
+        cursor = start_cursor
+        next_keys = []
+
+        if start_cursor + count >= data.length
+          next_keys = keys(match)[start_cursor..-1]
+          cursor = 0
+        else
+          cursor = start_cursor + 10
+          next_keys = keys(match)[start_cursor..cursor]
+        end
+
+        return "#{cursor}", next_keys
+      end
+
       def zadd(key, *args)
         if !args.first.is_a?(Array)
           if args.size < 2


### PR DESCRIPTION
I believe I've got the basic usage of SCAN implemented here. While COUNT in Redis proper doesn't exactly mean "return this number", that's basically what it will do. What this doesn't implement is that SCAN can return duplicate keys, but is guaranteed to return all keys in the database (applying a MATCH as requested). Instead this just iterates over the set.

This only implements SCAN. HSCAN, ZSCAN, and SSCAN should be relatively easy to add if necessary.

Redis documentation: http://redis.io/commands/scan
