### PR TITLE
stop running CI with deprecated rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.1
-  - ree
   - jruby-19mode
   - rbx-2


### PR DESCRIPTION
Glancing back in the history, I have seen some extra work to support long ago EOLed versions of ruby. 
