### PR TITLE
rpoplpush should not push when the source list is empty

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -365,7 +365,7 @@ class Redis
       def rpoplpush(key1, key2)
         data_type_check(key1, Array)
         rpop(key1).tap do |elem|
-          lpush(key2, elem)
+          lpush(key2, elem) unless elem.nil?
         end
       end
 

--- a/spec/lists_spec.rb
+++ b/spec/lists_spec.rb
@@ -176,6 +176,14 @@ module FakeRedis
       @client.lrange("key2", 0, -1).should be == ["three"]
     end
 
+    context 'when the source list is empty' do
+      it 'rpoplpush does not add anything to the destination list' do
+        @client.rpoplpush("source", "destination")
+
+        @client.lrange("destination", 0, -1).should be == []
+      end
+    end
+
     it "should append a value to a list" do
       @client.rpush("key1", "one")
       @client.rpush("key1", "two")


### PR DESCRIPTION
Redis rpoplpush from an empty list will not push anything into the destination. fakeredis currently pushes an empty string because lpush of nil works slightly differently from rpoplpush. 
