### PR TITLE
ltrim should return OK

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -258,17 +258,17 @@ class Redis
         data_type_check(key, Array)
         return unless data[key]
 
-        if start < 0 && data[key].count < start.abs
-          # Example: we have a list of 3 elements and
-          # we give it a ltrim list, -5, -1. This means
-          # it should trim to a max of 5. Since 3 < 5
-          # we should not touch the list. This is consistent
-          # with behavior of real Redis's ltrim with a negative
-          # start argument.
-          data[key]
-        else
+        # Example: we have a list of 3 elements and
+        # we give it a ltrim list, -5, -1. This means
+        # it should trim to a max of 5. Since 3 < 5
+        # we should not touch the list. This is consistent
+        # with behavior of real Redis's ltrim with a negative
+        # start argument.
+        unless start < 0 && data[key].count < start.abs
           data[key] = data[key][start..stop]
         end
+
+        "OK"
       end
 
       def lindex(key, index)

--- a/spec/lists_spec.rb
+++ b/spec/lists_spec.rb
@@ -119,7 +119,7 @@ module FakeRedis
       @client.rpush("key1", "two")
       @client.rpush("key1", "three")
 
-      @client.ltrim("key1", 1, -1)
+      @client.ltrim("key1", 1, -1).should be == "OK"
       @client.lrange("key1", 0, -1).should be == ["two", "three"]
     end
 


### PR DESCRIPTION
Ran into this when expecting `OK` on `ltrim`. Thought it might be a good chance to contribute to a great gem.

According to the [redis docs](http://redis.io/commands/ltrim), `LTRIM` will return `OK` on success.
