### PR TITLE
Expire returns 1 and 0, not true and nil.

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -505,9 +505,9 @@ class Redis
       end
 
       def expire(key, ttl)
-        return unless data[key]
+        return 0 unless data[key]
         data.expires[key] = Time.now + ttl
-        true
+        1
       end
 
       def ttl(key)

--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -29,6 +29,15 @@ module FakeRedis
       lambda { @client.del [] }.should raise_error(Redis::CommandError, "ERR wrong number of arguments for 'del' command")
     end
 
+    it "should return true when setting expires on keys that exist" do
+      @client.set("key1", "1")
+      @client.expire("key1", 1).should == true
+    end
+
+    it "should return false when attempting to set expires on a key that does not exist" do
+      @client.expire("key1", 1).should == false
+    end
+
     it "should determine if a key exists" do
       @client.set("key1", "1")
 

--- a/spec/transactions_spec.rb
+++ b/spec/transactions_spec.rb
@@ -24,10 +24,11 @@ module FakeRedis
         transaction = @client.multi do |multi|
           multi.set("key1", "1")
           multi.set("key2", "2")
+          multi.expire("key1", 123)
           multi.mget("key1", "key2")
         end
 
-        transaction.should be == ["OK", "OK", ["1", "2"]]
+        transaction.should be == ["OK", "OK", true, ["1", "2"]]
       end
     end
 


### PR DESCRIPTION
Found another case of an incorrect return value.

The `EXPIRE` command returns `0` and `1`. The `redis` gem then converts `0` and `1` responses to booleans with: https://github.com/redis/redis-rb/blob/master/lib/redis.rb#L307-L311

This PR corrects the return value of fakeredis' `expire` to return what redis would, `0` or `1`. This results in the `redis` gem correctly converting the response to a boolean.

I noticed this behavior as part of a `multi` so I added it to that example just to be safe, but also created entries in the `keys_spec.rb`.

The previous behavior was `expire` would always return false.
