### PR TITLE
Allow srem with multiple params

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -394,7 +394,17 @@ class Redis
 
       def srem(key, value)
         data_type_check(key, ::Set)
-        deleted = !!(data[key] && data[key].delete?(value.to_s))
+        return false unless data[key]
+
+        if value.is_a?(Array)
+          old_size = data[key].size
+          values = value.map(&:to_s)
+          values.each { |value| data[key].delete(value) }
+          deleted = old_size - data[key].size
+        else
+          deleted = !!data[key].delete?(value.to_s)
+        end
+
         remove_key_for_empty_collection(key)
         deleted
       end

--- a/spec/sets_spec.rb
+++ b/spec/sets_spec.rb
@@ -146,6 +146,14 @@ module FakeRedis
       @client.smembers("key1").should be == ["b"]
     end
 
+    it "should remove multiple members from a set" do
+      @client.sadd("key1", "a")
+      @client.sadd("key1", "b")
+
+      @client.srem("key1", [ "a", "b"]).should == 2
+      @client.smembers("key1").should be_empty
+    end
+
     it "should remove the set's key once it's empty" do
       @client.sadd("key1", "a")
       @client.sadd("key1", "b")


### PR DESCRIPTION
Allow srem with multiple params to work.

Follows the same idea of redis-rb#srem:
https://github.com/redis/redis-rb/blob/master/lib/redis.rb#L1239-L1247

Example:

```
$redis.sadd('key1', 'a')
$redis.sadd('key1', 'b')
$redis.sadd('key1', 'c')

$redis.srem('key1', 'a') 
=> true

$redis.srem('key1', 'b', 'c')
=> 2
```

Make this really fast because I needed... if you find something that could be done better, or any idea.. let me know.

Thanks
