### PR TITLE
Allow sort non-existing key

### DIFF
--- a/lib/fakeredis/sort_method.rb
+++ b/lib/fakeredis/sort_method.rb
@@ -3,6 +3,7 @@ module FakeRedis
   module SortMethod
     def sort(key, *redis_options_array)
       return [] unless key
+      return [] if type(key) == 'none'
 
       unless %w(list set zset).include? type(key)
         warn "Operation against a key holding the wrong kind of value: Expected list, set or zset at #{key}."

--- a/spec/sort_method_spec.rb
+++ b/spec/sort_method_spec.rb
@@ -32,6 +32,12 @@ module FakeRedis
       end
     end
 
+    context "none" do
+      it "should return empty array" do
+        @client.sort("key").should eq []
+      end
+    end
+
     context "list" do
       before do
         @key = "fake-redis-test:list_sort"


### PR DESCRIPTION
Tested on Redis 2.8.12
