### PR TITLE
Correct SETNX to return 0/1 as per redis docs

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -496,10 +496,10 @@ class Redis
 
       def setnx(key, value)
         if exists(key)
-          false
+          0
         else
           set(key, value)
-          true
+          1
         end
       end
 

--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -29,6 +29,15 @@ module FakeRedis
       lambda { @client.del [] }.should raise_error(Redis::CommandError, "ERR wrong number of arguments for 'del' command")
     end
 
+    it "should return true when setnx keys that don't exist" do
+      @client.setnx("key1", "1").should == true
+    end
+
+    it "should return false when setnx keys exist" do
+      @client.set("key1", "1")
+      @client.setnx("key1", "1").should == false
+    end
+
     it "should return true when setting expires on keys that exist" do
       @client.set("key1", "1")
       @client.expire("key1", 1).should == true


### PR DESCRIPTION
As per the comments on https://github.com/guilleiguaran/fakeredis/pull/110

And here are the docs for easy reference: http://redis.io/commands/setnx
