### PR TITLE
Ignore rbx2 failures on travis, but still test it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ rvm:
   - ruby-head
   - jruby
   - rbx-2
+matrix:
+  allow_failures:
+    - rvm: rbx-2


### PR DESCRIPTION
rbx 2 is currently failing on travis due to a gem install issue, and I believe we've seen issues with only it in the past. I still think it's worth us running the suite against rbx2, but we shouldn't fail an entire travis run if it errors or fails to run. This PR just marks the rbx2 build on travis as such.
