### PR TITLE
Use redis verison >= 3.0

### DIFF
--- a/fakeredis.gemspec
+++ b/fakeredis.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency(%q<redis>, ["~> 3.0"])
-  s.add_development_dependency(%q<rspec>, ["~> 3.0"])
+  s.add_runtime_dependency(%q<redis>, [">= 3.0"])
+  s.add_development_dependency(%q<rspec>, [">= 3.0"])
 end


### PR DESCRIPTION
We want to use the `redis` gem from the master branch, but we can not resolve our dependencies because `fakeredis` requires version `3.0` and the version in master is `3.1`. I edited the gemspec to make this work and all tests are green.
