### PR TITLE
Test against redis master on travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 .bundle
 Gemfile.lock
+gemfiles/*.gemfile.lock
 pkg/*
 .rvmrc
 *.rbc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ rvm:
   - ruby-head
   - jruby
   - rbx-2
+gemfile:
+  - Gemfile
+  - gemfiles/redisrb-master.gemfile
 matrix:
   allow_failures:
     - rvm: rbx-2

--- a/gemfiles/redisrb-master.gemfile
+++ b/gemfiles/redisrb-master.gemfile
@@ -1,0 +1,14 @@
+source "https://rubygems.org"
+
+gem 'rake'
+gem 'rdoc'
+gem "redis", github: "redis/redis-rb"
+
+platforms :rbx do
+  gem 'racc'
+  gem 'rubysl', '~> 2.0'
+  gem 'psych'
+end
+
+# Specify your gem's dependencies in fakeredis.gemspec
+gemspec :path => ".."


### PR DESCRIPTION
Using the :star2:power:star2: of the build matrix on travis, and with a separate gemfile that pulls in redis-rb gem's master branch from github, we have the ability to test fakeredis against both the latest released stable redis-rb gem, and the master version.
