### PR TITLE
Fix an rbx test failure

### DIFF
--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -406,9 +406,7 @@ module FakeRedis
       end
 
       it "errors with more than one argument" do
-        expect do
-          @client.dump("key1", "key2")
-        end.to raise_error(ArgumentError, /wrong number of arguments/)
+        expect { @client.dump("key1", "key2") }.to raise_error(ArgumentError)
       end
     end
 


### PR DESCRIPTION
We're testing that the method doesn't accept more than a single argument, and we don't need to test that ruby returns the right message here. (rbx has a different error message to MRI, but still raises `ArgumentError` as expected.)
