### PR TITLE
Use the faster container based travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: rbx-2
+# Use the faster container based infrastructure
+# http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
+sudo: false


### PR DESCRIPTION
As per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/ they have new docker-based infrastructure which is much quicker at running tests.

As we don't use sudo to install any packages as root, we can take advantage of this by setting `sudo: false` in our travis config. The last build I did before this took ~9 minutes, the build for this branch took ~4 minutes. Nice easy speedup!
