### PR TITLE
return OK from hmset

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -648,6 +648,7 @@ class Redis
             data[key][field[0].to_s] = field[1].to_s
           end
         end
+        "OK"
       end
 
       def hmget(key, *fields)


### PR DESCRIPTION
I noticed in my tests that although mapped_hmset returns  'OK', the fakeredis version returns nil.
So i added a simple "OK" as return value.
