### PR TITLE
disallow pushing empty list of objects

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -368,6 +368,7 @@ class Redis
       end
 
       def rpush(key, value)
+        raise_argument_error('rpush') if value.respond_to?(:each) && value.empty?
         data_type_check(key, Array)
         data[key] ||= []
         [value].flatten.each do |val|
@@ -377,12 +378,14 @@ class Redis
       end
 
       def rpushx(key, value)
+        raise_argument_error('rpushx') if value.respond_to?(:each) && value.empty?
         data_type_check(key, Array)
         return unless data[key]
         rpush(key, value)
       end
 
       def lpush(key, value)
+        raise_argument_error('lpush') if value.respond_to?(:each) && value.empty?
         data_type_check(key, Array)
         data[key] ||= []
         [value].flatten.each do |val|
@@ -392,6 +395,7 @@ class Redis
       end
 
       def lpushx(key, value)
+        raise_argument_error('lpushx') if value.respond_to?(:each) && value.empty?
         data_type_check(key, Array)
         return unless data[key]
         lpush(key, value)

--- a/spec/lists_spec.rb
+++ b/spec/lists_spec.rb
@@ -199,5 +199,13 @@ module FakeRedis
       @client.lrange("key1", 0, -1).should be == ["one", "two"]
       @client.lrange("key2", 0, -1).should be == []
     end
+
+    it 'should not allow pushing empty list of objects' do
+      expect { @client.lpush("key1", []) }.to raise_error(Redis::CommandError, /lpush[^x]/)
+      expect { @client.lpush("key1", 1); @client.lpushx("key1", []) }.to raise_error(Redis::CommandError, /lpushx/)
+
+      expect { @client.rpush("key1", []) }.to raise_error(Redis::CommandError, /rpush[^x]/)
+      expect { @client.rpush("key1", 1); @client.rpushx("key1", []) }.to raise_error(Redis::CommandError, /rpushx/)
+    end
   end
 end


### PR DESCRIPTION
Hi,

In Redis, it is not allowed to push empty list to a key (if that happens, that key will become an empty list)

This tiny patch fixes this problem for `fakeredis`

Before this patch, it was like:

```ruby
irb(main):021:0> redis.lpush 'a', []
=> 0
```

Now it is like:

```ruby
irb(main):003:0> redis.lpush 'a', []
Redis::CommandError: ERR wrong number of arguments for 'lpush' command
	from /Users/forresty/source/fakeredis/lib/redis/connection/memory.rb:1050:in `raise_argument_error'
	from /Users/forresty/source/fakeredis/lib/redis/connection/memory.rb:388:in `lpush'
	from /Users/forresty/source/fakeredis/lib/fakeredis/command_executor.rb:10:in `write'
```

This is the same behavior as the `redis-rb` gem