### PR TITLE
fix namespace conflict for minitest

### DIFF
--- a/lib/fakeredis/minitest.rb
+++ b/lib/fakeredis/minitest.rb
@@ -19,6 +19,6 @@ module FakeRedis
       Redis::Connection::Memory.reset_all_databases
     end
 
-    Minitest::Test.send(:include, self)
+    ::Minitest::Test.send(:include, self)
   end
 end


### PR DESCRIPTION
When using with minitest and ruby 2.2.2 I got this error : 

```
/home/titeiko/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fakeredis-4560a0725f48/lib/fakeredis/minitest.rb:22:in `<module:Minitest>': uninitialized constant FakeRedis::Minitest::Test (NameError)
```

So here's a minifix :)

Btw, no new versions published for more than a year even though there's (good) work being done ? :disappointed: 