### PR TITLE
Return 1 or 0 for hash set functions

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -684,10 +684,10 @@ class Redis
         if data[key]
           result = !data[key].include?(field)
           data[key][field] = value.to_s
-          result
+          result ? 1 : 0
         else
           data[key] = { field => value.to_s }
-          true
+          1
         end
       end
 

--- a/spec/transactions_spec.rb
+++ b/spec/transactions_spec.rb
@@ -80,5 +80,13 @@ module FakeRedis
         expect(responses[2]).to eq(1)
       end
     end
+
+    context 'executing hash commands in a block' do
+      it "returns true if the nested hash command succeeds" do
+        responses = @client.multi { |multi| multi.hset('hash', 'key', 'value') }
+
+        expect(responses[0]).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
The API redis-rb expects doesn't match the results provided by fakeredis.

* redis-rb calls [_boolify](https://github.com/redis/redis-rb/blob/master/lib/redis.rb#L2595) to convert a return of 1 into true for hash functions; everything else returns false

* With hash functions returning true or false, this doesn't match the expected API from redis-rb, so as you can tell from the spec I added, returning true from hset inside a multi results in an actual return value (from the multi) of false.