### PR TITLE
Update Sets interface for multiple keys methods

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -557,6 +557,7 @@ class Redis
       end
 
       def sinter(*keys)
+        keys = keys[0] if flatten?(keys)
         raise_argument_error('sinter') if keys.empty?
 
         keys.each { |k| data_type_check(k, ::Set) }
@@ -574,6 +575,9 @@ class Redis
       end
 
       def sunion(*keys)
+        keys = keys[0] if flatten?(keys)
+        raise_argument_error('sunion') if keys.empty?
+
         keys.each { |k| data_type_check(k, ::Set) }
         keys = keys.map { |k| data[k] || ::Set.new }
         keys.inject(::Set.new) do |set, key|
@@ -588,6 +592,7 @@ class Redis
       end
 
       def sdiff(key1, *keys)
+        keys = keys[0] if flatten?(keys)
         [key1, *keys].each { |k| data_type_check(k, ::Set) }
         keys = keys.map { |k| data[k] || ::Set.new }
         keys.inject(data[key1] || Set.new) do |memo, set|
@@ -1193,6 +1198,9 @@ class Redis
         def mapped_param? param
           param.size == 1 && param[0].is_a?(Array)
         end
+        # NOTE : Redis-rb 3.x will flatten *args, so method(["a", "b", "c"])
+        #        should be handled the same way as method("a", "b", "c")
+        alias_method :flatten?, :mapped_param?
 
         def srandmember_single(key)
           data_type_check(key, ::Set)

--- a/spec/sets_spec.rb
+++ b/spec/sets_spec.rb
@@ -16,6 +16,9 @@ module FakeRedis
     it "should raise error if command arguments count is not enough" do
       expect { @client.sadd("key", []) }.to raise_error(Redis::CommandError, "ERR wrong number of arguments for 'sadd' command")
       expect { @client.sinter(*[]) }.to raise_error(Redis::CommandError, "ERR wrong number of arguments for 'sinter' command")
+      expect { @client.sinter([]) }.to raise_error(Redis::CommandError, "ERR wrong number of arguments for 'sinter' command")
+      expect { @client.sunion(*[]) }.to raise_error(Redis::CommandError, "ERR wrong number of arguments for 'sunion' command")
+      expect { @client.sunion([]) }.to raise_error(Redis::CommandError, "ERR wrong number of arguments for 'sunion' command")
 
       expect(@client.smembers("key")).to be_empty
     end
@@ -44,6 +47,7 @@ module FakeRedis
       @client.sadd("key3", "e")
 
       expect(@client.sdiff("key1", "key2", "key3")).to match_array(["b", "d"])
+      expect(@client.sdiff("key1", ["key2", "key3"])).to match_array(["b", "d"])
     end
 
     it "should subtract from a nonexistent set" do
@@ -51,6 +55,7 @@ module FakeRedis
       @client.sadd("key2", "b")
 
       expect(@client.sdiff("key1", "key2")).to eq([])
+      expect(@client.sdiff(["key1", "key2"])).to eq([])
     end
 
     it "should subtract multiple sets and store the resulting set in a key" do
@@ -63,8 +68,10 @@ module FakeRedis
       @client.sadd("key3", "c")
       @client.sadd("key3", "e")
       @client.sdiffstore("key", "key1", "key2", "key3")
+      @client.sdiffstore("new_key", "key1", ["key2", "key3"])
 
       expect(@client.smembers("key")).to match_array(["b", "d"])
+      expect(@client.smembers("new_key")).to match_array(["b", "d"])
     end
 
     it "should intersect multiple sets" do
@@ -78,6 +85,7 @@ module FakeRedis
       @client.sadd("key3", "e")
 
       expect(@client.sinter("key1", "key2", "key3")).to eq(["c"])
+      expect(@client.sinter(["key1", "key2", "key3"])).to eq(["c"])
     end
 
     it "should intersect multiple sets and store the resulting set in a key" do
@@ -90,7 +98,10 @@ module FakeRedis
       @client.sadd("key3", "c")
       @client.sadd("key3", "e")
       @client.sinterstore("key", "key1", "key2", "key3")
+      @client.sinterstore("new_key", ["key1", "key2", "key3"])
+
       expect(@client.smembers("key")).to eq(["c"])
+      expect(@client.smembers("new_key")).to eq(["c"])
     end
 
     it "should determine if a given value is a member of a set" do


### PR DESCRIPTION
In redis-rb > 3.0.0 method call Redis#method(["a", "b", "c"]), become equal to Redis#method("a", "b", "c")
See more in [diff](https://github.com/redis/redis-rb/compare/v2.2.2...v3.0.0#diff-597c124889a64c18744b52ef9687c572R169)