### PR TITLE
Remove reversing SMEMBERS result

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -491,7 +491,7 @@ class Redis
       def smembers(key)
         data_type_check(key, ::Set)
         return [] unless data[key]
-        data[key].to_a.reverse
+        data[key].to_a
       end
 
       def sismember(key, value)

--- a/spec/sets_spec.rb
+++ b/spec/sets_spec.rb
@@ -23,10 +23,10 @@ module FakeRedis
       expect(@client.smembers("key")).to be_empty
     end
 
-    it "should add multiple members to a set" do
+    it "should add multiple members to a set and keep insertion order" do
       expect(@client.sadd("key", %w(value other something more))).to eq(4)
       expect(@client.sadd("key", %w(and additional values))).to eq(3)
-      expect(@client.smembers("key")).to match_array(["value", "other", "something", "more", "and", "additional", "values"])
+      expect(@client.smembers("key")).to eq ["value", "other", "something", "more", "and", "additional", "values"]
     end
 
     it "should get the number of members in a set" do


### PR DESCRIPTION
In redis-cli and redis-rb you receive set items in the same order as you insert them

```bash
$ redis-cli
redis> SADD "key" "1"
(integer) 1
redis> SADD "key" "2"
(integer) 1
redis> SADD "key" "3"
(integer) 1
redis> SMEMBERS "key"
1) "1"
2) "2"
3) "3"
```