### PR TITLE
List with non string values read/write

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -371,7 +371,9 @@ class Redis
       def linsert(key, where, pivot, value)
         data_type_check(key, Array)
         return unless data[key]
-        index = data[key].index(pivot)
+
+        value = value.to_s
+        index = data[key].index(pivot.to_s)
         case where
           when :before then data[key].insert(index, value)
           when :after  then data[key].insert(index + 1, value)
@@ -383,12 +385,14 @@ class Redis
         data_type_check(key, Array)
         return unless data[key]
         raise Redis::CommandError, "ERR index out of range" if index >= data[key].size
-        data[key][index] = value
+        data[key][index] = value.to_s
       end
 
       def lrem(key, count, value)
         data_type_check(key, Array)
         return 0 unless data[key]
+
+        value = value.to_s
         old_size = data[key].size
         diff =
           if count == 0

--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -374,6 +374,8 @@ class Redis
 
         value = value.to_s
         index = data[key].index(pivot.to_s)
+        return -1 if index.nil?
+
         case where
           when :before then data[key].insert(index, value)
           when :after  then data[key].insert(index + 1, value)

--- a/spec/lists_spec.rb
+++ b/spec/lists_spec.rb
@@ -19,8 +19,10 @@ module FakeRedis
       @client.rpush("key1", "v1")
       @client.rpush("key1", "v3")
       @client.linsert("key1", :before, "v3", "v2")
+      @client.linsert("key1", :after, "v3", 100)
+      @client.linsert("key1", :before, 100, 99)
 
-      expect(@client.lrange("key1", 0, -1)).to eq(["v1", "v2", "v3"])
+      expect(@client.lrange("key1", 0, -1)).to eq(["v1", "v2", "v3", "99", "100"])
     end
 
     it 'should allow multiple values to be added to a list in a single rpush' do
@@ -87,9 +89,11 @@ module FakeRedis
       @client.rpush("key1", "v2")
       @client.rpush("key1", "v2")
       @client.rpush("key1", "v1")
+      @client.rpush("key1", 42)
 
       expect(@client.lrem("key1", 1, "v1")).to eq(1)
       expect(@client.lrem("key1", -2, "v2")).to eq(2)
+      expect(@client.lrem("key1", 0, 42)).to eq(1)
       expect(@client.llen("key1")).to eq(2)
     end
 
@@ -114,9 +118,10 @@ module FakeRedis
 
       @client.lset("key1", 0, "four")
       @client.lset("key1", -2, "five")
-      expect(@client.lrange("key1", 0, -1)).to eq(["four", "five", "three"])
+      @client.lset("key1", 2, 6)
 
-      expect { @client.lset("key1", 4, "six") }.to raise_error(Redis::CommandError, "ERR index out of range")
+      expect(@client.lrange("key1", 0, -1)).to eq(["four", "five", "6"])
+      expect { @client.lset("key1", 4, "seven") }.to raise_error(Redis::CommandError, "ERR index out of range")
     end
 
     it "should trim a list to the specified range" do

--- a/spec/lists_spec.rb
+++ b/spec/lists_spec.rb
@@ -25,6 +25,14 @@ module FakeRedis
       expect(@client.lrange("key1", 0, -1)).to eq(["v1", "v2", "v3", "99", "100"])
     end
 
+    it "should not insert if after/before index not found" do
+      @client.rpush("key", "v1")
+      expect(@client.linsert("key", :before, "unknown", "v2")).to eq(-1)
+      expect(@client.linsert("key", :after, "unknown", "v3")).to eq(-1)
+
+      expect(@client.lrange("key", 0, -1)).to eq(["v1"])
+    end
+
     it 'should allow multiple values to be added to a list in a single rpush' do
       @client.rpush('key1', [1, 2, 3])
       expect(@client.lrange('key1', 0, -1)).to eq(['1', '2', '3'])


### PR DESCRIPTION
1. All values should be strings. We need to stringify when we store them, and when we fetch.
2. If you try to insert before/after nonexistent key, you will receive -1 response and your insertion will not occur