### PR TITLE
Raise error when score for sorted sets is not a valid float

### DIFF
--- a/lib/fakeredis/zset.rb
+++ b/lib/fakeredis/zset.rb
@@ -25,8 +25,10 @@ module FakeRedis
       elsif (( number = str.to_s.match(/^\((\d+)/i) ))
         number[1].to_i + (increment ? 1 : -1)
       else
-        Float str
+        Float str.to_s
       end
+    rescue ArgumentError
+      raise Redis::CommandError, "ERR value is not a valid float"
     end
 
   end

--- a/spec/sorted_sets_spec.rb
+++ b/spec/sorted_sets_spec.rb
@@ -66,6 +66,20 @@ module FakeRedis
       expect(@client.zscore("key", "val")).to eq(54.321)
     end
 
+    it "should allow strings that can be parsed as float when adding or updating" do
+      expect(@client.zadd("key", "4.321", "val")).to be(true)
+      expect(@client.zscore("key", "val")).to eq(4.321)
+
+      expect(@client.zadd("key", "54.3210", "val")).to be(false)
+      expect(@client.zscore("key", "val")).to eq(54.321)
+    end
+
+    it "should error when the score is not a valid float" do
+      expect { @client.zadd("key", "score", "val") }.to raise_error(Redis::CommandError, "ERR value is not a valid float")
+      expect { @client.zadd("key", {}, "val") }.to raise_error(Redis::CommandError, "ERR value is not a valid float")
+      expect { @client.zadd("key", Time.now, "val") }.to raise_error(Redis::CommandError, "ERR value is not a valid float")
+    end
+
     it "should remove members from sorted sets" do
       expect(@client.zrem("key", "val")).to be(false)
       expect(@client.zadd("key", 1, "val")).to be(true)


### PR DESCRIPTION
I noticed that the current implementation of `FakeRedis::ZSet#[]=` applies `_floatify` to the value passed as score. I think this doesn't reflect exactly how a real client (like `redis-rb`) works when passing a value that doesn't have a string representation that can't be converted to float (`_floatify` seems to be applied to the output only).

I run into this problem when I was passing a `Time` value to `zadd`. All my tests that used `fakeredis` worked without any issues, but the code failed in production with a a `ERR value is not a valid float` error. I have tweaked the `_floatify` method to not convert everything to float, and to return the same error as Redis when you pass something that cannot even be converted.