### PR TITLE
Fix off-by-one error in #scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg/*
 *.rbc
 .ruby-version
 .ruby-gemset
+bin

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem 'rake'
 gem 'rdoc'
+gem('pry-byebug')
 
 platforms :rbx do
   gem 'racc'

--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -929,7 +929,10 @@ class Redis
         final_page = start_cursor + count >= keys(match).length
 
         if final_page
-          returned_keys = keys(match)
+          previous_keys_been_deleted = (count >= keys(match).length)
+          start_index = previous_keys_been_deleted ? 0 : cursor
+
+          returned_keys = keys(match)[start_index..-1]
           cursor = 0
         else
           end_index = start_cursor + (count - 1)

--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -926,9 +926,10 @@ class Redis
 
         cursor = start_cursor
         returned_keys = []
+        final_page = start_cursor + count >= keys(match).length
 
-        if start_cursor + count >= keys(match).length
-          returned_keys = keys(match)[start_cursor..-1]
+        if final_page
+          returned_keys = keys(match)
           cursor = 0
         else
           end_index = start_cursor + (count - 1)

--- a/spec/memory_spec.rb
+++ b/spec/memory_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe FakeRedis do
       end
     end
 
+    context 'with one namespace' do
+      let(:match_arguments) { {} }
+
+      it 'returns the expected array of keys' do
+        expect(result).to match_array(redis.keys)
+      end
+    end
+
     context 'with multiple namespaces' do
       let(:namespaced_key) { 'test' }
       let(:match_arguments) { { match: namespaced_key } }

--- a/spec/memory_spec.rb
+++ b/spec/memory_spec.rb
@@ -26,11 +26,12 @@ RSpec.describe FakeRedis do
       populate_keys_in_redis(11)
     end
 
-    context 'with one namespace' do
-      let(:match_arguments) { {} }
-
-      it 'returns the expected array of keys' do
-        expect(result).to match_array(redis.keys)
+    context('when deleting') do
+      it('preverves cursor') do
+        cursor, keys = redis.scan('0')
+        keys.each { |key| redis.del(key) }
+        _, keys = redis.scan(cursor)
+        expect(keys).to eq(%w(key10))
       end
     end
 


### PR DESCRIPTION
We noticed that `#scan` was 

1. returning duplicate values where a chunk's endpoint index is the same as the next chunk's starting index point, and
2. When determining to end or continue the chunking, matches weren't accounted for; instead the size check was always on the entire dataset instead of the match value.