### PR TITLE
sort: handle offset above set range with an empty array

### DIFF
--- a/lib/fakeredis/sort_method.rb
+++ b/lib/fakeredis/sort_method.rb
@@ -101,7 +101,7 @@ module FakeRedis
       skip = limit.first || 0
       take = limit.last || sorted.length
 
-      sorted[skip...(skip + take)] || sorted
+      sorted[skip...(skip + take)] || []
     end
 
     def lookup_from_pattern(pattern, element)

--- a/spec/support/shared_examples/sortable.rb
+++ b/spec/support/shared_examples/sortable.rb
@@ -53,6 +53,10 @@ shared_examples_for "a sortable" do
     it 'only returns requested window in the enumerable' do
       expect(@client.sort(@key, :limit => [0, 1])).to eq(['1'])
     end
+
+    it 'returns an empty array if the offset if more than the length of the list' do
+      expect(@client.sort(@key, :limit => [3, 1])).to eq([])
+    end
   end
 
   context 'store' do


### PR DESCRIPTION
hello there @guilleiguaran,

with the current implementation, the sort method returns the whole set when the offset is beyond the set range

```
[4] pry(main)> require 'fakeredis'
=> true
[5] pry(main)> r = Redis.new
=> #<Redis client v3.2.2 for redis://127.0.0.1:6379/0>
[6] pry(main)> r.sadd('test', [1,2,3])
=> 3
[7] pry(main)> r.sort('test', by: 'nosort', limit: [1,1])
=> ["2"]
[8] pry(main)> r.sort('test', by: 'nosort', limit: [7,1])
=> ["1", "2", "3"]
```

this corrects that