### PR TITLE
Fix lrange implementation when negative start index is out of range

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -346,7 +346,14 @@ class Redis
 
       def lrange(key, startidx, endidx)
         data_type_check(key, Array)
-        (data[key] && data[key][startidx..endidx]) || []
+        if data[key]
+          # In Ruby when negative start index is out of range Array#slice returns
+          # nil which is not the case for lrange in Redis.
+          startidx = 0 if startidx < 0 && startidx.abs > data[key].size
+          data[key][startidx..endidx] || []
+        else
+          []
+        end
       end
 
       def ltrim(key, start, stop)

--- a/spec/lists_spec.rb
+++ b/spec/lists_spec.rb
@@ -89,6 +89,7 @@ module FakeRedis
       @client.rpush("key1", "v3")
 
       expect(@client.lrange("key1", 1, -1)).to eq(["v2", "v3"])
+      expect(@client.lrange("key1", -999, -1)).to eq(["v1", "v2", "v3"])
     end
 
     it "should remove elements from a list" do


### PR DESCRIPTION
`LRANGE` happily accepts out of range negative start index and returns elements from the beginning. `Array#slice` is not happy when given the same start index and returns `nil`. 

This PR fixes this difference.