### PR TITLE
Add enable and disable to FakeRedis

### DIFF
--- a/lib/fakeredis.rb
+++ b/lib/fakeredis.rb
@@ -3,4 +3,16 @@ require 'redis/connection/memory'
 
 module FakeRedis
   Redis = ::Redis
+
+  def self.enable
+    Redis::Connection.drivers << Redis::Connection::Memory unless enabled?
+  end
+
+  def self.enabled?
+    Redis::Connection.drivers.last == Redis::Connection::Memory
+  end
+
+  def self.disable
+    Redis::Connection.drivers.delete_if {|driver| Redis::Connection::Memory == driver }
+  end
 end

--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -1417,4 +1417,5 @@ class Redis
   end
 end
 
+# FIXME this line should be deleted as explicit enabling is better
 Redis::Connection.drivers << Redis::Connection::Memory

--- a/spec/fakeredis_spec.rb
+++ b/spec/fakeredis_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe FakeRedis do
+  after { described_class.disable }
+
+  describe '.enable' do
+    it 'in memory connection' do
+      described_class.enable
+      expect(described_class.enabled?).to be_truthy
+    end
+  end
+
+  describe '.disable' do
+    before { described_class.enable }
+
+    it 'in memory connection' do
+      described_class.disable
+      expect(described_class.enabled?).to be_falsy
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,11 @@ require "fakeredis/rspec"
 require "support/shared_examples/sortable"
 require "support/shared_examples/bitwise_operation"
 
+
 RSpec.configure do |config|
+  # Enable memory adapter
+  config.before(:each) { FakeRedis.enable }
+
   # replaces -b -fdoc --color in .rspec
   config.color = true
   config.default_formatter = "doc"
@@ -25,5 +29,5 @@ RSpec.configure do |config|
 end
 
 def fakeredis?
-  true
+  FakeRedis.enabled?
 end

--- a/spec/spec_helper_live_redis.rb
+++ b/spec/spec_helper_live_redis.rb
@@ -1,14 +1,14 @@
 require "spec_helper"
 
-# Remove memory so we test against actual redis
-Redis::Connection.drivers.pop
-
 RSpec.configure do |config|
   config.before(:each) do
+    # Disable so we test against actual redis
+    FakeRedis.disable
+
     Redis.new.flushall
   end
 end
 
 def fakeredis?
-  false
+  FakeRedis.enabled?
 end


### PR DESCRIPTION
As a developer I want to have more control over when fakeredis is active and when not. (see https://github.com/guilleiguaran/fakeredis/issues/63)

I think it is a bit too much magic when `FakeRedis` enables itsself, but I kept this feature in the codebase (I still would be happy to discuss this).