### PR TITLE
Fix Ruby 2.4.0 Ruby Fixnum deprecation warning

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -967,7 +967,7 @@ class Redis
         end
 
         start_cursor = start_cursor.to_i
-        data_type_check(start_cursor, Fixnum)
+        data_type_check(start_cursor, Integer)
 
         cursor = start_cursor
         returned_keys = []


### PR DESCRIPTION
Starting with Ruby 2.4, Fixnum and Bignum are unified into Integer. [article](http://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html)

Warning: 
/Users/pairing/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/fakeredis-0.6.0/lib/redis/connection/memory.rb:970: warning: constant ::Fixnum is deprecated