### PR TITLE
zremrangebyrank order lexicographically if scores are equal

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -1171,7 +1171,7 @@ class Redis
         data_type_check(key, ZSet)
         return 0 unless data[key]
 
-        sorted_elements = data[key].sort_by { |k, v| v }
+        sorted_elements = sort_keys(data[key])
         start = sorted_elements.length if start > sorted_elements.length
         elements_to_delete = sorted_elements[start..stop]
         elements_to_delete.each { |elem, rank| data[key].delete(elem) }

--- a/spec/sorted_sets_spec.rb
+++ b/spec/sorted_sets_spec.rb
@@ -356,6 +356,15 @@ module FakeRedis
       it "should return 0 if the key didn't exist" do
         expect(@client.zremrangebyrank("key", 0, 1)).to eq(0)
       end
+
+      it "should order lexicographically if scores are equal" do
+        @client.zadd("key", 1, "b")
+        @client.zadd("key", 1, "c")
+        @client.zadd("key", 1, "a")
+
+        expect(@client.zremrangebyrank("key", 0, 1)).to eq(2)
+        expect(@client.zrange("key", 0, -1)).to eq(["c"])
+      end
     end
 
     describe "#zunionstore" do


### PR DESCRIPTION
The current implementation does not fallback to lexicographical ordering if scores are equal. For example in `redis-cli`:

```
> ZRANGE "test" 0 -1
(empty list or set)
> ZADD "test" 1 "b"
(integer) 1
> ZADD "test" 1 "c"
(integer) 1
> ZADD "test" 1 "a"
(integer) 1
> ZRANGE "test" 0 -1
1) "a"
2) "b"
3) "c"
> ZREMRANGEBYRANK "test" 0 1
(integer) 2
> ZRANGE "test" 0 -1
1) "c"
```

The `sorted_keys` method, already used in `ZRANGE` already handles this scenario, it just needed to also be used in `ZREMRANGEBYRANK` as well.