### PR TITLE
Fix zinterstore so it intersects correctly

### DIFF
--- a/lib/fakeredis/sorted_set_store.rb
+++ b/lib/fakeredis/sorted_set_store.rb
@@ -68,7 +68,7 @@ module FakeRedis
 
   class SortedSetIntersectStore < SortedSetStore
     def selected_keys
-      @values ||= hashes.inject([]) { |r, h| r.empty? ? h.keys : (r & h.keys) }
+      @values ||= hashes.map(&:keys).reduce(:&)
     end
   end
 

--- a/spec/sorted_sets_spec.rb
+++ b/spec/sorted_sets_spec.rb
@@ -306,6 +306,16 @@ module FakeRedis
       it "should error with an invalid aggregate" do
         expect { @client.zinterstore("out", %w(key1 key2), :aggregate => :invalid) }.to raise_error(Redis::CommandError, "ERR syntax error")
       end
+
+      it 'stores nothing when there are no members in common' do
+        @client.zadd("k1", 1, "1")
+        @client.zadd("k1", 1, "2")
+        @client.sadd("k2", "a")
+        @client.sadd("k3", "b")
+
+        expect(@client.zinterstore("out", %w(k1 k2 k3))).to eq(0)
+        expect(@client.zrange("out", 0, -1)).to eq([])
+      end
     end
 
     context "zremrangebyscore" do


### PR DESCRIPTION
With the previous implementation, if you give it 3 sets and the first 2 have no elements in common, it would return elements of the 3rd set.