### PR TITLE
rails-redis-instrumentation does now work properly when using FakeRedis

### DIFF
--- a/lib/fakeredis/command_executor.rb
+++ b/lib/fakeredis/command_executor.rb
@@ -1,13 +1,14 @@
 module FakeRedis
   module CommandExecutor
     def write(command)
-      meffod = command.shift.to_s.downcase.to_sym
+      meffod = command[0].to_s.downcase.to_sym
+      args = command[1..-1]
 
       if in_multi && !(TRANSACTION_COMMANDS.include? meffod) # queue commands
-        queued_commands << [meffod, *command]
+        queued_commands << [meffod, *args]
         reply = 'QUEUED'
       elsif respond_to?(meffod)
-        reply = send(meffod, *command)
+        reply = send(meffod, *args)
       else
         raise Redis::CommandError, "ERR unknown command '#{meffod}'"
       end

--- a/spec/command_executor_spec.rb
+++ b/spec/command_executor_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe FakeRedis::CommandExecutor do
+  
+  let(:redis) { Redis.new }
+
+  context '#write' do
+    it 'does not modify its argument' do
+      command = [:get, 'key']
+      redis.write(command)
+      expect(command).to eql([:get, 'key'])
+    end
+  end
+
+end


### PR DESCRIPTION
I'm using the [rails-redis-instrumentation](https://github.com/lautis/redis-rails-instrumentation) gem to log Redis commands just like SQL commands in my Rails logfiles. 

When switching between real-Redis and FakeRedis, I noticed that the command names were missing in the log output. This is caused by `CommandExecutor#write` which modifies the command it receives as argument. 

```
FakeRedis::CommandExecutor
  #write
    does not modify its argument (FAILED - 1)

Failures:

  1) FakeRedis::CommandExecutor#write does not modify its argument
     Failure/Error: expect(command).to eql([:get, 'key'])
     
       expected: [:get, "key"]
            got: ["key"]
     
       (compared using eql?)
     
       Diff:
       @@ -1,2 +1,2 @@
       -[:get, "key"]
       +["key"]
```

