### PR TITLE
Ruby 2.4 Fixnum to Integer Fix

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -1289,7 +1289,7 @@ class Redis
         end
 
         start_cursor = start_cursor.to_i
-        data_type_check(start_cursor, Fixnum)
+        data_type_check(start_cursor, Integer)
 
         cursor = start_cursor
         next_keys = []


### PR DESCRIPTION
This was already fixed for scan in https://github.com/guilleiguaran/fakeredis/pull/180, this fixes the deprecation warning for zscan.