### PR TITLE
Fix NoMethodError in zrange

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -1081,7 +1081,7 @@ class Redis
         results = sort_keys(data[key])
         # Select just the keys unless we want scores
         results = results.map(&:first) unless with_scores
-        results[start..stop].flatten.map(&:to_s)
+        (results[start..stop] || []).flatten.map(&:to_s)
       end
 
       def zrangebylex(key, start, stop, *opts)

--- a/spec/sorted_sets_spec.rb
+++ b/spec/sorted_sets_spec.rb
@@ -316,6 +316,12 @@ module FakeRedis
         expect(@client.zinterstore("out", %w(k1 k2 k3))).to eq(0)
         expect(@client.zrange("out", 0, -1)).to eq([])
       end
+
+      it 'handles range start being higher than number of members' do
+        @client.zadd("key", 1, "1")
+
+        expect(@client.zrange("key", 10, 10)).to eq([])
+      end
     end
 
     context "zremrangebyscore" do


### PR DESCRIPTION
This fixes #187.

When the start index of the zrange is higher than the number of members stored, we were calling `nil.flatten`. Lets fix this (& test it) by returning an empty array, which the rest of the line is happy to noop about and return an empty array to the caller.