### PR TITLE
Handle linsert position token regardless of case

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -386,9 +386,9 @@ class Redis
         index = data[key].index(pivot.to_s)
         return -1 if index.nil?
 
-        case where
-          when :before then data[key].insert(index, value)
-          when :after  then data[key].insert(index + 1, value)
+        case where.to_s
+          when /\Abefore\z/i then data[key].insert(index, value)
+          when /\Aafter\z/i  then data[key].insert(index + 1, value)
           else raise_syntax_error
         end
       end

--- a/spec/lists_spec.rb
+++ b/spec/lists_spec.rb
@@ -25,6 +25,18 @@ module FakeRedis
       expect(@client.lrange("key1", 0, -1)).to eq(["v1", "v2", "v3", "99", "100"])
     end
 
+    it "inserts with case-insensitive position token" do
+      @client.rpush("key1", "v1")
+      @client.rpush("key1", "v4")
+
+      @client.linsert("key1", :BEFORE, "v4", "v2")
+      @client.linsert("key1", "Before", "v4", "v3")
+      @client.linsert("key1", :AFTER, "v4", "v5")
+      @client.linsert("key1", "After", "v5", "v6")
+
+      expect(@client.lrange("key1", 0, -1)).to eq(%w(v1 v2 v3 v4 v5 v6))
+    end
+
     it "should not insert if after/before index not found" do
       @client.rpush("key", "v1")
       expect(@client.linsert("key", :before, "unknown", "v2")).to eq(-1)


### PR DESCRIPTION
We will accept any mix of upper and lower case in `:before` and `:after`

Fixes #153