### PR TITLE
Fix unknown client command

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -89,6 +89,9 @@ class Redis
       def disconnect
       end
 
+      def client(command, options)
+      end
+
       def timeout=(usecs)
       end
 

--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -89,7 +89,13 @@ class Redis
       def disconnect
       end
 
-      def client(command, options)
+      def client(command, options = {})
+        case command
+        when :setname then true
+        when :getname then nil
+        else
+          raise Redis::CommandError, "ERR unknown command '#{command}'"
+        end
       end
 
       def timeout=(usecs)

--- a/spec/memory_spec.rb
+++ b/spec/memory_spec.rb
@@ -84,4 +84,18 @@ RSpec.describe FakeRedis do
       end
     end
   end
+
+  describe '#client' do
+    it 'returns 1 when command is :setname' do
+      expect(redis.write([:client, :setname])).to eq 1
+    end
+
+    it 'returns nil when command is :getname' do
+      expect(redis.write([:client, :getname])).to eq nil
+    end
+
+    it 'raises error for other commands' do
+      expect { redis.write([:client, :wrong]) }.to raise_error(Redis::CommandError, "ERR unknown command 'wrong'")
+    end
+  end
 end


### PR DESCRIPTION
After updating to Sidekick 5.0.4 I get the following error when running the first test of my test suite:

```ruby
Failure/Error: dead_job_count = Sidekiq::DeadSet.new.size

     Redis::CommandError:
       ERR unknown command 'client'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/fakeredis-0.6.0/lib/fakeredis/command_executor.rb:12:in `write'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:271:in `block in write'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:250:in `io'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:269:in `write'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:228:in `block (3 levels) in process'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:222:in `each'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:222:in `block (2 levels) in process'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:367:in `ensure_connected'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:221:in `block in process'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:306:in `logging'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:220:in `process'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:120:in `call'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:104:in `block in connect'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:293:in `with_reconnect'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:100:in `connect'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:364:in `ensure_connected'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:221:in `block in process'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:306:in `logging'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:220:in `process'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis/client.rb:120:in `call'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis.rb:1475:in `block in zcard'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis.rb:58:in `block in synchronize'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis.rb:58:in `synchronize'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/redis-3.3.3/lib/redis.rb:1474:in `zcard'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/sidekiq-5.0.4/lib/sidekiq/api.rb:525:in `block in size'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/sidekiq-5.0.4/lib/sidekiq.rb:95:in `block in redis'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/connection_pool-2.2.1/lib/connection_pool.rb:64:in `block (2 levels) in with'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/connection_pool-2.2.1/lib/connection_pool.rb:63:in `handle_interrupt'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/connection_pool-2.2.1/lib/connection_pool.rb:63:in `block in with'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/connection_pool-2.2.1/lib/connection_pool.rb:60:in `handle_interrupt'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/connection_pool-2.2.1/lib/connection_pool.rb:60:in `with'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/sidekiq-5.0.4/lib/sidekiq.rb:92:in `redis'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/sidekiq-5.0.4/lib/sidekiq/api.rb:525:in `size'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/sidekiq-5.0.4/lib/sidekiq/api.rb:521:in `initialize'
     # /Users/tiagotex/.rvm/gems/ruby-2.3.1/gems/sidekiq-5.0.4/lib/sidekiq/api.rb:663:in `initialize'
     # ./lib/sidekiq_health_checker.rb:19:in `new'
     # ./lib/sidekiq_health_checker.rb:19:in `run'
     # ./spec/lib/sidekiq_health_checker_spec.rb:13:in `block (5 levels) in <top (required)>'
```

There are multiple tests in the test file, but only the first fails.

In `redis-3.3.3/lib/redis/client.rb:100`:

```ruby
def connect
  @pid = Process.pid

  # Don't try to reconnect when the connection is fresh
  with_reconnect(false) do
    establish_connection
    call [:auth, password] if password
    call [:select, db] if db != 0
    call [:client, :setname, @options[:id]] if @options[:id]
    @connector.check(self)
  end

  self
end
```

In previous versions the line `call [:client, :setname, @options[:id]] if @options[:id]` was ignored but since version 5.0.4 Sidekiq sets the `@options[:id]` with the client identifier https://github.com/mperham/sidekiq/commit/980438c61dd226b661cdac4e76f20dab61d1243c

Fakeredis doesn't seem to implement the `client` method so I have implemented the simplest solution to make my tests pass, let me know if there is a better solution or if you want me to make changes.