### PR TITLE
enhancement: Support client command by returning a fake answer

### DIFF
--- a/lib/fakeredis/transaction_commands.rb
+++ b/lib/fakeredis/transaction_commands.rb
@@ -1,5 +1,5 @@
 module FakeRedis
-  TRANSACTION_COMMANDS = [:discard, :exec, :multi, :watch, :unwatch]
+  TRANSACTION_COMMANDS = [:discard, :exec, :multi, :watch, :unwatch, :client]
 
   module TransactionCommands
     def self.included(klass)

--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -56,6 +56,7 @@ class Redis
       def database_id
         @database_id ||= 0
       end
+
       attr_writer :database_id
 
       def database_instance_key
@@ -89,10 +90,11 @@ class Redis
       def disconnect
       end
 
-      def client(command, options = {})
+      def client(command, _options = {})
         case command
         when :setname then true
         when :getname then nil
+        when :client then true
         else
           raise Redis::CommandError, "ERR unknown command '#{command}'"
         end

--- a/spec/memory_spec.rb
+++ b/spec/memory_spec.rb
@@ -94,6 +94,10 @@ RSpec.describe FakeRedis do
       expect(redis.write([:client, :getname])).to eq nil
     end
 
+    it 'returns true when the comment is :client with an argument' do
+      expect(redis.write([:client, :client, :list])).to eq 1
+    end
+
     it 'raises error for other commands' do
       expect { redis.write([:client, :wrong]) }.to raise_error(Redis::CommandError, "ERR unknown command 'wrong'")
     end

--- a/spec/transactions_spec.rb
+++ b/spec/transactions_spec.rb
@@ -33,7 +33,7 @@ module FakeRedis
     end
 
     context '#discard' do
-      it "should responde with 'OK' after #multi" do
+      it "should respond with 'OK' after #multi" do
         @client.multi
         expect(@client.discard).to eq('OK')
       end


### PR DESCRIPTION
Hey @guilleiguaran,

Description
-----------

Support `client` redis command.

![screen shot 2017-10-12 at 3 07 02 pm](https://user-images.githubusercontent.com/344518/31521691-0fcaa5ae-af70-11e7-97b9-f95b7da1364f.png)

Changes in this PR doesn't mock properly the client command but prevent the gem from raising and error when the command is used.

@guilleiguaran  if you believe this command should return a similar answer to the one on the image (and the information to build that answer is available), let me know and I will be glad to implement it. 

Why I had to do this
--------------------

I was trying to use `fakeredis` in a project that use `sidekiq-superworker` and I was getting the following error:

`Redis::CommandError: ERR unknown command 'client'`

Best regards,
Daniel.

