### PR TITLE
Fix returning value for multi

### DIFF
--- a/lib/fakeredis/command_executor.rb
+++ b/lib/fakeredis/command_executor.rb
@@ -19,6 +19,8 @@ module FakeRedis
         reply = 1
       elsif reply == false
         reply = 0
+      elsif reply.is_a?(Array)
+        reply = reply.map { |r| r == true ? 1 : r == false ? 0 : r }
       end
 
       replies << reply

--- a/spec/transactions_spec.rb
+++ b/spec/transactions_spec.rb
@@ -88,5 +88,18 @@ module FakeRedis
         expect(responses[0]).to eq(true)
       end
     end
+
+    context 'executing set commands in a block' do
+      it "returns commands' responses for nested commands" do
+        @client.sadd('set', 'member1')
+
+        responses = @client.multi do |multi|
+          multi.sadd('set', 'member1')
+          multi.sadd('set', 'member2')
+        end
+
+        expect(responses).to eq([false, true])
+      end
+    end
   end
 end


### PR DESCRIPTION
When reply is an array (like `[true, false]`), it is then incorrectly converted into array of `false`s here https://github.com/redis/redis-rb/blob/b362cf23173bd2fea8b4cbd63bfff696fffbb84c/lib/redis.rb#L1336

Fixes #166