### PR TITLE
Fix brpoplpush pushing to destination and returned value

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -493,9 +493,9 @@ class Redis
 
       def brpoplpush(key1, key2, opts={})
         data_type_check(key1, Array)
-        brpop(key1).tap do |elem|
-          lpush(key2, elem) unless elem.nil?
-        end
+        _key, elem = brpop(key1)
+        lpush(key2, elem) unless elem.nil?
+        elem
       end
 
       def lpop(key)

--- a/spec/lists_spec.rb
+++ b/spec/lists_spec.rb
@@ -196,7 +196,7 @@ module FakeRedis
       expect(@client.lrange("key1", 0, -1)).to eq(["one", "two"])
     end
 
-    it "should remove the last element in a list, append it to another list and return it" do
+    it "rpoplpush should remove the last element in a list, append it to another list and return it" do
       @client.rpush("key1", "one")
       @client.rpush("key1", "two")
       @client.rpush("key1", "three")
@@ -207,9 +207,26 @@ module FakeRedis
       expect(@client.lrange("key2", 0, -1)).to eq(["three"])
     end
 
+    it "brpoplpush should remove the last element in a list, append it to another list and return it" do
+      @client.rpush("key1", "one")
+      @client.rpush("key1", "two")
+      @client.rpush("key1", "three")
+
+      expect(@client.brpoplpush("key1", "key2")).to eq("three")
+
+      expect(@client.lrange("key1", 0, -1)).to eq(["one", "two"])
+      expect(@client.lrange("key2", 0, -1)).to eq(["three"])
+    end
+
     context 'when the source list is empty' do
       it 'rpoplpush does not add anything to the destination list' do
         @client.rpoplpush("source", "destination")
+
+        expect(@client.lrange("destination", 0, -1)).to eq([])
+      end
+
+      it 'brpoplpush does not add anything to the destination list' do
+        expect(@client.brpoplpush("source", "destination")).to be_nil
 
         expect(@client.lrange("destination", 0, -1)).to eq([])
       end


### PR DESCRIPTION
There is a bug in what this method returns and what pushes to destination.

```ruby
  test "#brpoplpush" do
    redis = Redis.new
    redis.lpush("list1", [1, 2, 3])
    element = redis.brpoplpush("list1", "list2")

    assert_equal "1", redis.brpoplpush("list1", "list2") # but equals to ["list1", "2"]
    assert_equal ["3", "2"], redis.lrange("list1", 0, -1)
    assert_equal ["1"], redis.lrange("list2", 0, -1) # but equals to ["1", "list1"]
  end
```