### PR TITLE
Fix bug in zrange

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -1102,6 +1102,7 @@ class Redis
         results = sort_keys(data[key])
         # Select just the keys unless we want scores
         results = results.map(&:first) unless with_scores
+        start = [start, -results.size].max
         (results[start..stop] || []).flatten.map(&:to_s)
       end
 

--- a/spec/sorted_sets_spec.rb
+++ b/spec/sorted_sets_spec.rb
@@ -147,6 +147,7 @@ module FakeRedis
 
       expect(@client.zrange("key", 0, -1)).to eq(["one", "two", "three"])
       expect(@client.zrange("key", 1, 2)).to eq(["two", "three"])
+      expect(@client.zrange("key", -50, -2)).to eq(["one", "two"])
       expect(@client.zrange("key", 0, -1, :withscores => true)).to eq([["one", 1], ["two", 2], ["three", 3]])
       expect(@client.zrange("key", 1, 2, :with_scores => true)).to eq([["two", 2], ["three", 3]])
     end


### PR DESCRIPTION
The current `zrange` implementation seems not to exactly replicate Redis zrange functionality.

e.g.
```
redis.zadd 'key', 1, 'one'
redis.zadd 'key', 2, 'two'
redis.zadd 'key', 3, 'three'

# Using real Redis
redis.zrange 'key', -50, -2
=> ["one", "two"]

# Using FakeRedis
redis.zrange 'key', -50, -2
=> nil
```

Similar bug with similar fix from `mock-redis` gem: https://github.com/brigade/mock_redis/pull/128