### PR TITLE
allow custom version to be provided (enables working with current Sidekiq)

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -13,6 +13,8 @@ require "fakeredis/version"
 
 class Redis
   module Connection
+    DEFAULT_REDIS_VERSION = '3.3.5'
+
     class Memory
       include Redis::Connection::CommandHelper
       include FakeRedis
@@ -130,7 +132,7 @@ class Redis
 
       def info
         {
-          "redis_version" => options[:version] || "2.6.16",
+          "redis_version" => options[:version] || DEFAULT_REDIS_VERSION,
           "connected_clients" => "1",
           "connected_slaves" => "0",
           "used_memory" => "3187",

--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -51,7 +51,7 @@ class Redis
       end
 
       def initialize(options = {})
-        self.options = options
+        self.options = self.options ? self.options.merge(options) : options
       end
 
       def database_id
@@ -130,7 +130,7 @@ class Redis
 
       def info
         {
-          "redis_version" => "2.6.16",
+          "redis_version" => options[:version] || "2.6.16",
           "connected_clients" => "1",
           "connected_slaves" => "0",
           "used_memory" => "3187",

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -100,9 +100,14 @@ module FakeRedis
 
   describe 'custom options' do
     describe 'version' do
+      it 'reports default Redis version when not provided' do
+        client = Redis.new
+        expect(client.info['redis_version']).to eq Redis::Connection::DEFAULT_REDIS_VERSION
+      end
+
       it 'creates with and reports properly' do
-        client = Redis.new(version: '3.3.5')
-        expect(client.info['redis_version']).to eq '3.3.5'
+        client = Redis.new(version: '3.3.0')
+        expect(client.info['redis_version']).to eq '3.3.0'
       end
     end
   end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -97,4 +97,13 @@ module FakeRedis
       end
     end
   end
+
+  describe 'custom options' do
+    describe 'version' do
+      it 'creates with and reports properly' do
+        client = Redis.new(version: '3.3.5')
+        expect(client.info['redis_version']).to eq '3.3.5'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi,

I'm using `fakeredis` with Sidekiq via:

```
redis_opts[:driver] = Redis::Connection::Memory

Sidekiq.configure_server do |config|
  config.redis = redis_opts
end

Sidekiq.configure_client do |config|
  config.redis = redis_opts
end
```

The above bypasses Sidekiq's attempt to connect to the Redis host.  That's great 👍 

But unfortunately, Sidekiq is still being rather strict and checking the `redis_version` reported by the `info` call via the client:
```
You are using Redis v2.6.16, Sidekiq requires Redis v2.8.0 or greater
```

This PR allows adding another option to customize the Redis version to make Sidekiq happy:
```
redis_opts[:version] = '3.3.5'
```

Added a quick spec.