### PR TITLE
hmget raises if the second argument is an empty list

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -805,7 +805,7 @@ class Redis
       end
 
       def hmget(key, *fields)
-        raise_argument_error('hmget')  if fields.empty?
+        raise_argument_error('hmget')  if fields.empty? || fields.flatten.empty?
 
         data_type_check(key, Hash)
         fields.flatten.map do |field|

--- a/spec/hashes_spec.rb
+++ b/spec/hashes_spec.rb
@@ -122,6 +122,10 @@ module FakeRedis
       expect { @client.hmget("key1") }.to raise_error(Redis::CommandError)
     end
 
+    it "should throw an argument error when the list of keys you ask for is empty" do
+      expect { @client.hmget("key1", []) }.to raise_error(Redis::CommandError)
+    end
+
     it "should reject an empty list of values" do
       expect { @client.hmset("key") }.to raise_error(Redis::CommandError)
       expect(@client.exists("key")).to be false


### PR DESCRIPTION
Hello and thank you for all your efforts, very much appreciated!

I ran into a situation today where I was seeing the error message "wrong number of arguments for hmget"    in a situation that had worked in unit tests and development environment:
```
ERROR -- : ERR wrong number of arguments for 'hmget' command (Redis::CommandError) 
Oct 16 18:16:16 : /app/vendor/bundle/ruby/2.4.0/gems/redis-3.3.5/lib/redis.rb:2026:in `block in hmget' 
Oct 16 18:16:16 : /app/vendor/bundle/ruby/2.4.0/gems/redis-3.3.5/lib/redis.rb:2025:in `hmget' 
```

After investigating this is caused by a discrepancy in behavior between fake-redis and the redis-3.3.5 gem if `hmget` is called with an empty list. The splat causes the empty list to come in as `[[]]` which itself is not empty, and thus was not causing an error in the fake-redis library.

Thank you again for all of your efforts as a maintainer of such a helpful tool!
