### PR TITLE
Fixed Ruby warnings.

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -1459,7 +1459,7 @@ class Redis
 
         def sort_keys(arr)
           # Sort by score, or if scores are equal, key alphanum
-          sorted_keys = arr.sort do |(k1, v1), (k2, v2)|
+          arr.sort do |(k1, v1), (k2, v2)|
             if v1 == v2
               k1 <=> k2
             else

--- a/spec/sets_spec.rb
+++ b/spec/sets_spec.rb
@@ -242,7 +242,7 @@ module FakeRedis
         it 'is an array of one random element from the set' do
           random_elements = @client.srandmember("key1", 1)
 
-          expect([['a'], ['b'], ['c']].include?(@client.srandmember("key1", 1))).to be true
+          expect([['a'], ['b'], ['c']].include?(random_elements)).to be true
         end
       end
 


### PR DESCRIPTION
Fixes "warning: assigned but unused variable"
Can be seen by setting RUBYOPT='-w' while running tests or just loading code.