### PR TITLE
Redis#mget - handle int keys too

### DIFF
--- a/lib/fakeredis/expiring_hash.rb
+++ b/lib/fakeredis/expiring_hash.rb
@@ -44,10 +44,8 @@ module FakeRedis
     end
 
     def values_at(*keys)
-      keys.each do |key|
-        key = normalize(key)
-        delete(key) if expired?(key)
-      end
+      keys = keys.map { |key| normalize(key) }
+      keys.each { |key| delete(key) if expired?(key) }
       super
     end
 

--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -130,6 +130,13 @@ module FakeRedis
       expect(@client.exists("key1")).to be false
     end
 
+    it "should get integer and string keys" do
+      @client.set("key1", "1")
+      @client.set(2, "2")
+
+      expect(@client.mget("key1", 2)).to eq(["1", "2"])
+    end
+
     it "should find all keys matching the given pattern" do
       @client.set("key:a", "1")
       @client.set("key:b", "2")


### PR DESCRIPTION
1. When we do a `mget` which calls `values_at`, we normalize the keys only for checking expiration and deleting the key. Then when we call `super` the keys are passed as is without `normalize`.

2. Added a failing spec too.

Please let me know if you have any feedback on this.