### PR TITLE
Implements temporal disable and enable

### DIFF
--- a/lib/fakeredis.rb
+++ b/lib/fakeredis.rb
@@ -15,4 +15,20 @@ module FakeRedis
   def self.disable
     Redis::Connection.drivers.delete_if {|driver| Redis::Connection::Memory == driver }
   end
+
+  def self.disabling
+    return yield unless enabled?
+
+    disable
+    yield
+    enable
+  end
+
+  def self.enabling
+    return yield if enabled?
+
+    enable
+    yield
+    disable
+  end
 end

--- a/spec/fakeredis_spec.rb
+++ b/spec/fakeredis_spec.rb
@@ -18,4 +18,56 @@ describe FakeRedis do
       expect(described_class.enabled?).to be_falsy
     end
   end
+
+  describe '.disabling' do
+    context 'FakeRedis is enabled' do
+      before { described_class.enable }
+
+      it 'in memory connection' do
+        described_class.disabling do
+          expect(described_class.enabled?).to be_falsy
+        end
+
+        expect(described_class.enabled?).to be_truthy
+      end
+    end
+
+    context 'FakeRedis is disabled' do
+      before { described_class.disable }
+
+      it 'in memory connection' do
+        described_class.disabling do
+          expect(described_class.enabled?).to be_falsy
+        end
+
+        expect(described_class.enabled?).to be_falsy
+      end
+    end
+  end
+
+  describe '.enabling' do
+    context 'FakeRedis is enabled' do
+      before { described_class.enable }
+
+      it 'in memory connection' do
+        described_class.enabling do
+          expect(described_class.enabled?).to be_truthy
+        end
+
+        expect(described_class.enabled?).to be_truthy
+      end
+    end
+
+    context 'FakeRedis is disabled' do
+      before { described_class.disable }
+
+      it 'in memory connection' do
+        described_class.enabling do
+          expect(described_class.enabled?).to be_truthy
+        end
+
+        expect(described_class.enabled?).to be_falsy
+      end
+    end
+  end
 end


### PR DESCRIPTION
**CHANGE:**

Ensures running a given block with `FakeRedis` either disabled or enabled, keeping the original state after the block execution. 

**USE:**

```rb
# disabling

puts FakeRedis.enabled?  # => true

FakeRedis.disabling do
  puts FakeRedis.enabled?  # => false
end

puts FakeRedis.enabled?  # => true

FakerRedis.disable

FakeRedis.disabling do
  puts FakeRedis.enabled?  # => false
end

puts FakeRedis.enabled?  # => false
```

```rb
# enabling

puts FakeRedis.enabled?  # => true

FakeRedis.enabling do
  puts FakeRedis.enabled?  # => true
end

puts FakeRedis.enabled?  # => true

FakerRedis.disable

FakeRedis.enabling do
  puts FakeRedis.enabled?  # => true
end

puts FakeRedis.enabled?  # => false
```

@guilleiguaran @caius 