### PR TITLE
Mirror msetnx test to check return value

### DIFF
--- a/spec/strings_spec.rb
+++ b/spec/strings_spec.rb
@@ -243,8 +243,8 @@ module FakeRedis
     end
 
     it "should set the value of a key, only if the key does not exist" do
-      @client.set("key1", "test value")
-      @client.setnx("key1", "new value")
+      expect(@client.setnx("key1", "test value")).to eq(true)
+      expect(@client.setnx("key1", "new value")).to eq(false)
       @client.setnx("key2", "another value")
 
       expect(@client.get("key1")).to eq("test value")


### PR DESCRIPTION
This is pretty minor, but before realizing that my issue with `setnx` returning 1/0 was already fixed in master, I was going through these tests and realized that nothing was explicitly checking the return value. For `msetnx`, the test looks like:
```ruby
it "should set multiple keys to multiple values, only if none of the keys exist" do
    expect(@client.msetnx(:key1, "value1", :key2, "value2")).to eq(true)
    expect(@client.msetnx(:key1, "value3", :key2, "value4")).to eq(false)

    expect(@client.get("key1")).to eq("value1")
    expect(@client.get("key2")).to eq("value2")
end
```
Which checks both that the return value is properly true/false, and that the keys do not get overridden. I figured making this test similar would be an easy way to get a little extra coverage for free.