### PR TITLE
add evalsha, eval methods to memory connection

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -150,9 +150,13 @@ class Redis
 
       def save; end
 
-      def bgsave ; end
+      def bgsave; end
 
-      def bgrewriteaof ; end
+      def bgrewriteaof; end
+
+      def evalsha; end
+
+      def eval; end
 
       def move key, destination_id
         raise Redis::CommandError, "ERR source and destination objects are the same" if destination_id == database_id


### PR DESCRIPTION
Reason for pull request: Using message_bus gem to broadcast messages through redis.
Gem versions:
- message bus: v2.2.3
- redis: v4.1.3

Received unknown command error for `evalsha` method from https://github.com/guilleiguaran/fakeredis/blob/master/lib/fakeredis/command_executor.rb#L15

FIX: 
added empty methods in memory connection so respond_to?(:evalsha) or respond_to?(:eval) return true.