### PR TITLE
Raise an error for mget when values are not strings

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -240,9 +240,9 @@ class Redis
       end
 
       def mget(*keys)
+        keys = keys[0] if flatten?(keys)
         raise_argument_error('mget') if keys.empty?
-        # We work with either an array, or list of arguments
-        keys = keys.first if keys.size == 1
+        keys.each { |key| data_type_check(key, String) }
         data.values_at(*keys)
       end
 

--- a/spec/strings_spec.rb
+++ b/spec/strings_spec.rb
@@ -183,6 +183,12 @@ module FakeRedis
       expect { @client.mget }.to raise_error(Redis::CommandError)
     end
 
+    it 'raises an argument error when the data is a hash' do
+      @client.hincrby("key1", "cont1", 5)
+
+      expect { @client.mget("key1") }.to raise_error(Redis::CommandError)
+    end
+
     it "should set multiple keys to multiple values" do
       @client.mset(:key1, "value1", :key2, "value2")
 


### PR DESCRIPTION
A fix for issue: https://github.com/guilleiguaran/fakeredis/issues/250

This will throw an error when trying to call `mget` on a key whose value is not a string.