### PR TITLE
Add exists? for Redis 5.0 compatibility

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -362,6 +362,10 @@ class Redis
         data.key?(key) ? 1 : 0
       end
 
+      def exists?(key)
+        data.key?(key)
+      end
+
       def llen(key)
         data_type_check(key, Array)
         return 0 unless data[key]

--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -508,6 +508,15 @@ module FakeRedis
         expect(@client.psetex("key", 1000, "value")).to eq("OK")
       end
     end
+
+    describe "#exists?" do
+      it "should return a boolean" do
+        @client.set("key1", "1")
+
+        expect(@client.exists?("key1")).to eq(true)
+        expect(@client.exists?("key2")).to eq(false)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
For those opting into Redis >=4.3, `Redis#exists?` is now used to return a `bool` for key-checks. This adds the new method to `fakeredis` so tests depending on this functionality work.