### PR TITLE
Ensure CommandError is raised if non-integer is passed to EX or PX

### DIFF
--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -504,6 +504,10 @@ module FakeRedis
         expect(@client.pttl("key")).to be_within(0.1).of(2200)
       end
 
+      it "should raise an error if a non-integer is provided as the expiration" do
+        expect { @client.psetex("key", 100.5, "value") }.to raise_error(Redis::CommandError)
+      end
+
       it "should return 'OK'" do
         expect(@client.psetex("key", 1000, "value")).to eq("OK")
       end

--- a/spec/strings_spec.rb
+++ b/spec/strings_spec.rb
@@ -242,6 +242,10 @@ module FakeRedis
       expect(@client.ttl("key1")).to eq(30)
     end
 
+    it "should raise an error if a non-integer is provided as the expiration" do
+      expect { @client.setex("key1", 1.5, "value1") }.to raise_error(Redis::CommandError)
+    end
+
     it "should set the value of a key, only if the key does not exist" do
       expect(@client.setnx("key1", "test value")).to eq(true)
       expect(@client.setnx("key1", "new value")).to eq(false)

--- a/spec/strings_spec.rb
+++ b/spec/strings_spec.rb
@@ -244,6 +244,7 @@ module FakeRedis
 
     it "should raise an error if a non-integer is provided as the expiration" do
       expect { @client.setex("key1", 1.5, "value1") }.to raise_error(Redis::CommandError)
+      expect { @client.set("key1", "value1", ex: 1.5) }.to raise_error(Redis::CommandError)
     end
 
     it "should set the value of a key, only if the key does not exist" do


### PR DESCRIPTION
The standard Redis client will raise `Redis::CommandError` (ERR value is not an integer or out of range) if any non-integer value is provided for expiration. This ensures that FakeRedis validates in the same fashion. This seemed to me to be the minimal refactor, although it does introduce redundancy between setex and psetex. An alternative implementation would reverse the previous arrangement, have `setex` always multiply the TTL by 1000 to produce a milliseconds value, and have the `expire` method always "do the math" assuming milliseconds.