### PR TITLE
For rspec, clear in the around block instead of the before block

### DIFF
--- a/lib/fakeredis/rspec.rb
+++ b/lib/fakeredis/rspec.rb
@@ -16,9 +16,10 @@ require 'fakeredis'
 
 RSpec.configure do |c|
 
-  c.before do    
+  c.around do |ex|
     Redis::Connection::Memory.reset_all_databases
     Redis::Connection::Memory.reset_all_channels
+    ex.run
   end
 
 end


### PR DESCRIPTION
Due to hook order we clear on `around` instead of `before`. This is because if we clear in `before`, `before` runs **after** `around` does and therefore overrides any redis based changes we make in the around hook.

If we clear in `around`, we can make changes to redis in **both** the around and before hooks!

People may rely on the previous confusing behavior implicitly, so I recommend potentially making this a minor/major version change.