### PR TITLE
Fix missing cursor when no data is found in the zscan method

### DIFF
--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -1442,7 +1442,7 @@ class Redis
 
       def zscan(key, start_cursor, *args)
         data_type_check(key, ZSet)
-        return [] unless data[key]
+        return '0', [] unless data[key] # return cursor 0, indicating end of iteration
 
         match = "*"
         count = 10

--- a/spec/sorted_sets_spec.rb
+++ b/spec/sorted_sets_spec.rb
@@ -497,30 +497,41 @@ module FakeRedis
     end
 
     describe "#zscan" do
-      before { 50.times { |x| @client.zadd("key", x, "key #{x}") } }
-
-      it 'with no arguments should return 10 numbers in ascending order' do
-        result = @client.zscan("key", 0)[1]
-        expect(result).to eq(result.sort { |x, y| x[1] <=> y[1] })
-        expect(result.count).to eq(10)
+      context 'without data' do
+        it 'return cursor 0 with an empty array' do
+          result = @client.zscan("notexistkey", 0)
+          expect(result.count).to eq 2
+          expect(result[0]).to eq '0'
+          expect(result[1]).to eq []
+        end
       end
 
-      it 'with a count should return that number of members' do
-        expect(@client.zscan("key", 0, count: 2)).to eq(["2", [["key 0", 0.0], ["key 1", 1.0]]])
-      end
+      context 'with data' do
+        before { 50.times { |x| @client.zadd("key", x, "key #{x}") } }
 
-      it 'with a count greater than the number of members, returns all the members in asc order' do
-        result = @client.zscan("key", 0, count: 1000)[1]
-        expect(result).to eq(result.sort { |x, y| x[1] <=> y[1] })
-        expect(result.size).to eq(50)
-      end
+        it 'with no arguments should return 10 numbers in ascending order' do
+          result = @client.zscan("key", 0)[1]
+          expect(result).to eq(result.sort { |x, y| x[1] <=> y[1] })
+          expect(result.count).to eq(10)
+        end
 
-      it 'with match, should return key-values where the key matches' do
-        @client.zadd("key", 1.0, "blah")
-        @client.zadd("key", 2.0, "bluh")
-        result = @client.zscan("key", 0, count: 100, match: "key*")[1]
-        expect(result).to_not include(["blah", 1.0])
-        expect(result).to_not include(["bluh", 2.0])
+        it 'with a count should return that number of members' do
+          expect(@client.zscan("key", 0, count: 2)).to eq(["2", [["key 0", 0.0], ["key 1", 1.0]]])
+        end
+
+        it 'with a count greater than the number of members, returns all the members in asc order' do
+          result = @client.zscan("key", 0, count: 1000)[1]
+          expect(result).to eq(result.sort { |x, y| x[1] <=> y[1] })
+          expect(result.size).to eq(50)
+        end
+
+        it 'with match, should return key-values where the key matches' do
+          @client.zadd("key", 1.0, "blah")
+          @client.zadd("key", 2.0, "bluh")
+          result = @client.zscan("key", 0, count: 100, match: "key*")[1]
+          expect(result).to_not include(["blah", 1.0])
+          expect(result).to_not include(["bluh", 2.0])
+        end
       end
     end
 


### PR DESCRIPTION
Issue: When no data is found, the current `zscan` method only returns an empty array, while the expected output should also contain the cursor with value "0"
Ref: https://github.com/guilleiguaran/fakeredis/blob/c28f7ac05ed3d32cd66041627b4239f32b2f2447/lib/redis/connection/memory.rb#L1445

<img width="484" alt="Screenshot 2024-05-26 at 12 20 04" src="https://github.com/guilleiguaran/fakeredis/assets/1097697/9a3c1e29-be91-4d39-9c0d-07a72aece3d8">


This PR updates the method `zscan` to also return the cursor "0" which indicates end of iteration when no data is found. 