### PR TITLE
Ensure UTC time is used for expiration time checks

### DIFF
--- a/lib/fakeredis/expiring_hash.rb
+++ b/lib/fakeredis/expiring_hash.rb
@@ -34,7 +34,7 @@ module FakeRedis
 
     def expired?(key)
       key = normalize key
-      expires.include?(key) && expires[key] <= Time.now
+      expires.include?(key) && expires[key] <= Time.now.utc
     end
 
     def key?(key)

--- a/lib/redis/connection/memory.rb
+++ b/lib/redis/connection/memory.rb
@@ -743,13 +743,13 @@ class Redis
 
       def expire(key, ttl)
         return 0 unless data[key]
-        data.expires[key] = Time.now + ttl
+        data.expires[key] = Time.now.utc + ttl
         1
       end
 
       def pexpire(key, ttl)
         return 0 unless data[key]
-        data.expires[key] = Time.now + (ttl / 1000.0)
+        data.expires[key] = Time.now.utc + (ttl / 1000.0)
         1
       end
 

--- a/spec/keys_spec.rb
+++ b/spec/keys_spec.rb
@@ -76,7 +76,7 @@ module FakeRedis
     end
 
     it "should set a key's time to live in miliseconds" do
-      allow(Time).to receive(:now).and_return(1000)
+      allow(Time).to receive(:now).and_return(Time.at(1000))
       @client.set("key1", "1")
       @client.pexpire("key1", 2200)
       expect(@client.pttl("key1")).to be_within(0.1).of(2200)
@@ -497,7 +497,7 @@ module FakeRedis
 
     describe "#psetex" do
       it "should set a key's time to live in milliseconds" do
-        allow(Time).to receive(:now).and_return(1000)
+        allow(Time).to receive(:now).and_return(Time.at(1000))
         @client.psetex("key", 2200, "value")
         expect(@client.pttl("key")).to be_within(0.1).of(2200)
       end


### PR DESCRIPTION
This resolves potential timing issues when TZ is a timezone with DST and a spec crosses a DST boundary with an expiring key. Without ensuring UTC time we could expire a key an hour early or an hour late.